### PR TITLE
Enable waiting for response for #publish_message

### DIFF
--- a/lib/manageiq/messaging/background_job.rb
+++ b/lib/manageiq/messaging/background_job.rb
@@ -46,9 +46,8 @@ module ManageIQ
         obj = obj.find(instance_id) if instance_id
 
         msg_timeout = 600 # TODO: configurable per message
-        result = nil
-        Timeout.timeout(msg_timeout) do
-          result = obj.send(options[:method_name], *args)
+        result = Timeout.timeout(msg_timeout) do
+          obj.send(options[:method_name], *args)
         end
 
         run_job(miq_callback) if miq_callback

--- a/lib/manageiq/messaging/background_job.rb
+++ b/lib/manageiq/messaging/background_job.rb
@@ -19,8 +19,8 @@ module ManageIQ
             result = run_job(msg_options.merge(:class_name => msg.headers['class_name'], :method_name => msg.headers['message_type']))
             logger.info("Background job completed")
 
-            correlation_id = msg.headers['correlation_id']
-            send_response(client, options[:service], correlation_id, result) if correlation_id
+            correlation_ref = msg.headers['correlation_id']
+            send_response(client, options[:service], correlation_ref, result) if correlation_ref
           rescue Timeout::Error
             logger.warn("Background job timed out")
             if Object.const_defined?('ActiveRecord::Base')

--- a/lib/manageiq/messaging/background_job.rb
+++ b/lib/manageiq/messaging/background_job.rb
@@ -16,8 +16,11 @@ module ManageIQ
             msg_options = decode_body(msg.headers, msg.body)
             msg_options = {} if msg_options.empty?
             logger.info("Processing background job: queue(#{queue_name}), job(#{msg_options.inspect}), headers(#{msg.headers})")
-            run_job(msg_options.merge(:class_name => msg.headers['class_name'], :method_name => msg.headers['message_type']))
+            result = run_job(msg_options.merge(:class_name => msg.headers['class_name'], :method_name => msg.headers['message_type']))
             logger.info("Background job completed")
+
+            correlation_id = msg.headers['correlation_id']
+            send_response(client, options[:service], correlation_id, result) if correlation_id
           rescue Timeout::Error
             logger.warn("Background job timed out")
             if Object.const_defined?('ActiveRecord::Base')
@@ -43,11 +46,13 @@ module ManageIQ
         obj = obj.find(instance_id) if instance_id
 
         msg_timeout = 600 # TODO: configurable per message
+        result = nil
         Timeout.timeout(msg_timeout) do
-          obj.send(options[:method_name], *args)
+          result = obj.send(options[:method_name], *args)
         end
 
         run_job(miq_callback) if miq_callback
+        result
       end
       private_class_method :run_job
     end

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -32,8 +32,10 @@ module ManageIQ
       #   :sender_id (optional, identity of the publisher)
       #   <other queue options TBA>
       #
-      def publish_message(options)
-        Queue.publish(self, options)
+      # Optionally a call back block {|response| block} can be provided to wait on
+      # the consumer to send an acknowledgment.
+      def publish_message(options, &block)
+        Queue.publish(self, options, &block)
       end
 
       # Publish multiple messages to a queue.
@@ -124,3 +126,4 @@ module ManageIQ
     end
   end
 end
+

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -11,8 +11,11 @@ module ManageIQ
         client = StompClient.new(options)
         return client unless block_given?
         if block_given?
-          yield client
-          client.close
+          begin
+            yield client
+          ensure
+            client.close
+          end
           nil
         end
       end

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -28,8 +28,7 @@ module ManageIQ
       #     :instance_id
       #     :args
       #     :miq_callback
-      #   :sender    (optional, type of the publisher)
-      #   :sender_id (optional, identity of the publisher)
+      #   :sender    (optional, identify the sender)
       #   <other queue options TBA>
       #
       # Optionally a call back block {|response| block} can be provided to wait on
@@ -63,7 +62,7 @@ module ManageIQ
       #       msg.sender
       #       msg.message
       #       msg.payload
-      #       msg.ack_id (used to ack the message)
+      #       msg.ack_ref (used to ack the message)
       #     end
       #   end
       #
@@ -75,7 +74,7 @@ module ManageIQ
       # current subscriber disconnects normally or abnormally (e.g. crashed).
       # Make sure a message is properly acked whatever strategy you take.
       #
-      # To ack a message call `ack(msg.ack_id)`
+      # To ack a message call `ack(msg.ack_ref)`
       def subscribe_messages(options, &block)
         raise "A block is required" unless block_given?
 
@@ -100,8 +99,7 @@ module ManageIQ
       #   :service   (service is used to determine the topic address)
       #   :event     (event name)
       #   :payload   (user defined structure that describes the event)
-      #   :sender    (optional, type of the publisher)
-      #   :sender_id (optional, identity of the publisher)
+      #   :sender    (optional, identify the sender)
       #   <other queue options TBA>
       #
       def publish_topic(options)
@@ -110,11 +108,11 @@ module ManageIQ
 
       # Subscribe to receive topic type messages.
       # @param options [Hash] attributes to configure how to receive messages
-      #   :service    (service is used to determine the topic address)
-      #   :persist_id (optional, client needs to be have client_id to use this feature)
+      #   :service     (service is used to determine the topic address)
+      #   :persist_ref (optional, client needs to be have client_ref to use this feature)
       #
       # Persisted event: In order to consume events missed during the period when the client is
-      # offline, the subscriber needs to be reconnect always with the same client_id and persist_id
+      # offline, the subscriber needs to be reconnect always with the same client_ref and persist_ref
       #
       # A callback {|sender, event, payload| block } needs to be provided to consume the topic
       #

--- a/lib/manageiq/messaging/common.rb
+++ b/lib/manageiq/messaging/common.rb
@@ -53,7 +53,7 @@ module ManageIQ
           queue_name = "topic/#{options[:service]}"
 
           headers = {:"subscription-type" => 'MULTICAST', :ack => 'client'}
-          headers[:"durable-subscription-name"] = options[:persist_id] if options[:persist_id]
+          headers[:"durable-subscription-name"] = options[:persist_ref] if options[:persist_ref]
 
           [queue_name, headers]
         end
@@ -75,19 +75,19 @@ module ManageIQ
           YAML.load(raw_body)
         end
 
-        def send_response(client, service, correlation_id, result)
+        def send_response(client, service, correlation_ref, result)
           response_options = {
             :service  => "#{service}.response",
-            :affinity => correlation_id
+            :affinity => correlation_ref
           }
           address, response_headers = queue_for_publish(response_options)
-          raw_publish(client, address, result || '', response_headers.merge(:correlation_id => correlation_id))
+          raw_publish(client, address, result || '', response_headers.merge(:correlation_id => correlation_ref))
         end
 
-        def receive_response(client, service, correlation_id)
+        def receive_response(client, service, correlation_ref)
           response_options = {
             :service  => "#{service}.response",
-            :affinity => correlation_id
+            :affinity => correlation_ref
           }
           queue_name, response_headers = queue_for_subscribe(response_options)
           client.subscribe(queue_name, response_headers) do |msg|

--- a/lib/manageiq/messaging/common.rb
+++ b/lib/manageiq/messaging/common.rb
@@ -92,8 +92,11 @@ module ManageIQ
           queue_name, response_headers = queue_for_subscribe(response_options)
           client.subscribe(queue_name, response_headers) do |msg|
             client.ack(msg)
-            yield decode_body(msg.headers, msg.body)
-            client.unsubscribe(queue_name)
+            begin
+              yield decode_body(msg.headers, msg.body)
+            ensure
+              client.unsubscribe(queue_name)
+            end
           end
         end
       end

--- a/lib/manageiq/messaging/queue.rb
+++ b/lib/manageiq/messaging/queue.rb
@@ -23,7 +23,7 @@ module ManageIQ
         messages.each { |options| publish(client, options) }
       end
 
-      Struct.new("Message", :sender, :message, :payload, :ack_id)
+      Struct.new("Message", :sender, :message, :payload, :ack_ref)
 
       def self.subscribe(client, options)
         assert_options(options, [:service])
@@ -40,8 +40,8 @@ module ManageIQ
           result = yield [Struct::Message.new(sender, message_type, message_body, msg)]
           logger.info("Message processed")
 
-          correlation_id = msg.headers['correlation_id']
-          send_response(client, options[:service], correlation_id, result) if correlation_id
+          correlation_ref = msg.headers['correlation_id']
+          send_response(client, options[:service], correlation_ref, result) if correlation_ref
         end
       end
     end

--- a/lib/manageiq/messaging/stomp_client.rb
+++ b/lib/manageiq/messaging/stomp_client.rb
@@ -15,15 +15,15 @@ module ManageIQ
       #   :username
       #   :password
       #   :port
-      #   :client_id (optional)
-      #   :heartbeat (optional, default to true)
+      #   :client_ref (optional)
+      #   :heartbeat  (optional, default to true)
       def initialize(options)
         host = {:host => options[:host], :port => options[:port]}
         host[:passcode] = options[:password] if options[:password]
         host[:login] = options[:username] if options[:username]
         headers = {}
         headers.merge!(:host => options[:host], :"accept-version" => "1.2", :"heart-beat" => "2000,0") unless options[:heartbeat] == false
-        headers.merge!(:"client-id" => options[:client_id]) if options[:client_id]
+        headers.merge!(:"client-id" => options[:client_ref]) if options[:client_ref]
 
         @stomp_client = Stomp::Client.new(:hosts => [host], :connect_headers => headers)
       end

--- a/lib/manageiq/messaging/stomp_client.rb
+++ b/lib/manageiq/messaging/stomp_client.rb
@@ -1,10 +1,11 @@
 module ManageIQ
   module Messaging
     class StompClient < Client
-      delegate :subscribe, :to => :stomp_client
-      delegate :publish,   :to => :stomp_client
-      delegate :close,     :to => :stomp_client
-      delegate :ack,       :to => :stomp_client
+      delegate :subscribe,   :to => :stomp_client
+      delegate :unsubscribe, :to => :stomp_client
+      delegate :publish,     :to => :stomp_client
+      delegate :close,       :to => :stomp_client
+      delegate :ack,         :to => :stomp_client
 
       private
       attr_reader :stomp_client


### PR DESCRIPTION
If the `client.publish_message` has a block, consider the message requires a response from the subscriber and the block will be executed upon receiving the response.

The typical usage is
```
  client.publish_message(options) do |result|
    # run this block when receiving a response from the subscriber. Expect result to be an empty string
    # if no execution result is needed.
    # the result does not need to be a string, can be a Hash for example.
  end
```
It make no sense to add similar feature to `#publish_topic` or `#publish_messages`.