### PR TITLE
Fix merge of manageiq-messaging.gemspec

### DIFF
--- a/manageiq-messaging.gemspec
+++ b/manageiq-messaging.gemspec
@@ -27,9 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-<<<<<<< 4fd654fd133243bafddbffeb6eda7cd4f2b8ba57
   spec.add_development_dependency "rubocop"
-=======
->>>>>>> General cleanup of README and documentation
   spec.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
Remove remnants from a merge conflict in the gemspec preventing `gem install`

```
/home/agrare/.bundle/ruby/2.3.0/manageiq-messaging-68211e634430/manageiq-messaging.gemspec:32: syntax error, unexpected ===, expecting keyword_end
=======
   ^. Bundler cannot continue.

 #  from /home/agrare/.bundle/ruby/2.3.0/manageiq-messaging-68211e634430/manageiq-messaging.gemspec:30
 #  -------------------------------------------
 #    spec.add_development_dependency "rspec", "~> 3.0"
 >  <<<<<<< 4fd654fd133243bafddbffeb6eda7cd4f2b8ba57
 #    spec.add_development_dependency "rubocop"
 #  -------------------------------------------
```