### PR TITLE
Fix a typo for correlation_ref

### DIFF
--- a/lib/manageiq/messaging/stomp/common.rb
+++ b/lib/manageiq/messaging/stomp/common.rb
@@ -6,7 +6,7 @@ module ManageIQ
 
         def raw_publish(address, body, headers)
           publish(address, encode_body(headers, body), headers)
-          logger.info("Published to address(#{address}), msg(#{body.inspect}), headers(#{headers.inspect})")
+          logger.info("Published to address(#{address}), msg(#{payload_log(body.inspect)}), headers(#{headers.inspect})")
         end
 
         def queue_for_publish(options)
@@ -59,6 +59,10 @@ module ManageIQ
         def decode_body(headers, raw_body)
           return raw_body unless headers['encoding'] == 'yaml'
           YAML.load(raw_body)
+        end
+
+        def payload_log(payload)
+          payload.to_s[0..100]
         end
 
         def send_response(service, correlation_ref, result)

--- a/lib/manageiq/messaging/stomp/queue.rb
+++ b/lib/manageiq/messaging/stomp/queue.rb
@@ -28,13 +28,13 @@ module ManageIQ
             sender = msg.headers['sender']
             message_type = msg.headers['message_type']
             message_body = decode_body(msg.headers, msg.body)
-            logger.info("Message received: queue(#{queue_name}), msg(#{message_body}), headers(#{msg.headers})")
+            logger.info("Message received: queue(#{queue_name}), msg(#{payload_log(message_body)}), headers(#{msg.headers})")
 
             result = yield [Struct::ManageIQ_Messaging_ReceivedMessage.new(sender, message_type, message_body, msg)]
             logger.info("Message processed")
 
             correlation_ref = msg.headers['correlation_id']
-            if correlation_id
+            if correlation_ref
               result = result.first if result.kind_of?(Array)
               send_response(options[:service], correlation_ref, result)
             end

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -21,7 +21,7 @@ module ManageIQ
               sender = event.headers['sender']
               event_type = event.headers['event_type']
               event_body = decode_body(event.headers, event.body)
-              logger.info("Event received: queue(#{queue_name}), event(#{event_body}), headers(#{event.headers})")
+              logger.info("Event received: queue(#{queue_name}), event(#{payload_log(event_body)}), headers(#{event.headers})")
               yield sender, event_type, event_body
               logger.info("Event processed")
             end


### PR DESCRIPTION
1. Fix a typo for correlation_ref
2. Limit the length of message body to be logged.

We have the use case for publishing large size message. As a quick and temporary solution I simply truncate the logging of message body to 100 characters. A more sophisticated handling including filtering sensitive data in a message body may need.