### PR TITLE
Defaults to STOMP Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Or install it yourself as:
   ManageIQ::Messaging.logger = Logger.new(STDOUT)
 
   client = ManageIQ::Messaging::Client.open(
-    :Stomp,
     :host       => 'localhost',
     :port       => 61616,
     :password   => 'smartvm',

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -4,18 +4,15 @@ module ManageIQ
       require 'manageiq/messaging/stomp/client'
 
       # Open or create a connection to the message broker
-      # @param type [String or Symbol] client type, available choices are:
-      #   :Stomp
-      #   :AMQP
-      #   :MiqQueue
       # @param options [Hash] the connection options
       # @return [Client, nil] the client object if no block is given
       #   The optional block supply {|client| block }. The client will
       #   be automatically closed when the block terminates
       #
       # Avaiable type:
-      def self.open(type = :Stomp, options)
-        client = Object.const_get("ManageIQ::Messaging::#{type}::Client").new(options)
+      def self.open(options)
+        protocol = options[:protocol] || :Stomp
+        client = Object.const_get("ManageIQ::Messaging::#{protocol}::Client").new(options)
         return client unless block_given?
 
         begin

--- a/spec/manageiq/messaging/client_spec.rb
+++ b/spec/manageiq/messaging/client_spec.rb
@@ -21,7 +21,7 @@ describe ManageIQ::Messaging::Client do
     ManageIQ::Messaging.send(:remove_const, :Test)
   end
 
-  subject { described_class.open('Test', {}) }
+  subject { described_class.open({:protocol => 'Test'}) }
 
   describe '.open' do
     it 'creates an instance of a type specific client' do
@@ -29,7 +29,7 @@ describe ManageIQ::Messaging::Client do
     end
 
     it 'closes the client before exit if it opens with a block' do
-      described_class.open('Test', {}) do |client|
+      described_class.open(:protocol => 'Test') do |client|
         expect(client).to receive(:close)
       end
     end


### PR DESCRIPTION
User doesn't have to specify the protocol, stomp is used by default.
If the caller wants to override the protocol they can pass it part of the options hash
