### PR TITLE
allow yaml or json encoding

### DIFF
--- a/lib/manageiq/messaging/stomp/client.rb
+++ b/lib/manageiq/messaging/stomp/client.rb
@@ -16,17 +16,19 @@ module ManageIQ
         private *delegate(:subscribe, :unsubscribe, :publish, :to => :stomp_client)
         delegate :ack, :close, :to => :stomp_client
 
+        attr_accessor :encoding
+
         private
 
         attr_reader :stomp_client
 
-        # options
-        #   :host
-        #   :username
-        #   :password
-        #   :port
-        #   :client_ref (optional)
-        #   :heartbeat  (optional, default to true)
+        # @options options :host
+        # @options options :username
+        # @options options :password
+        # @options options :port
+        # @options options :client_ref (optional)
+        # @options options :heartbeat  (optional, default to true)
+        # @options options :encoding (default to 'yaml')
         def initialize(options)
           host = options.slice(:host, :port)
           host[:passcode] = options[:password] if options[:password]
@@ -42,6 +44,8 @@ module ManageIQ
           end
           headers[:"client-id"] = options[:client_ref] if options[:client_ref]
 
+          @encoding = options[:encoding] || 'yaml'
+          require "json" if @encoding == "json"
           @stomp_client = ::Stomp::Client.new(:hosts => [host], :connect_headers => headers)
         end
       end

--- a/lib/manageiq/messaging/stomp/common.rb
+++ b/lib/manageiq/messaging/stomp/common.rb
@@ -53,13 +53,26 @@ module ManageIQ
 
         def encode_body(headers, body)
           return body if body.kind_of?(String)
-          headers[:encoding] = 'yaml'
-          body.to_yaml
+          headers[:encoding] = encoding
+          case encoding
+          when "json"
+            JSON.generate(body)
+          when "yaml"
+            body.to_yaml
+          else
+            raise "unknown message encoding: #{encoding}"
+          end
         end
 
         def decode_body(headers, raw_body)
-          return raw_body unless headers['encoding'] == 'yaml'
-          YAML.load(raw_body)
+          case headers["encoding"]
+          when "json"
+            JSON.parse(raw_body)
+          when "yaml"
+            YAML.load(raw_body)
+          else
+            raw_body
+          end
         end
 
         def payload_log(payload)


### PR DESCRIPTION
Json is 95% faster than yaml. [[ref]](https://gist.github.com/kbrock/978baec148501587f8160864815c07ac)

Json has no native support for dates or symbols. But since our goal is to support multiple languages, this may be a good thing.

Not ready to make a complete break, but this allows us to experiment with the various encoding.
It also allows a developer to add a custom encoder when initializing the client.

~~This does require us to `require "json"` first.~~
