### PR TITLE
Add :group_name option

### DIFF
--- a/lib/manageiq/messaging/stomp/common.rb
+++ b/lib/manageiq/messaging/stomp/common.rb
@@ -14,9 +14,10 @@ module ManageIQ
           address = "queue/#{options[:service]}.#{affinity}"
 
           headers = {:"destination-type" => 'ANYCAST'}
-          headers[:expires] = options[:expires_on].to_i * 1000 if options[:expires_on]
+          headers[:expires]            = options[:expires_on].to_i * 1000 if options[:expires_on]
           headers[:AMQ_SCHEDULED_TIME] = options[:deliver_on].to_i * 1000 if options[:deliver_on]
-          headers[:priority] = options[:priority] if options[:priority]
+          headers[:priority]           = options[:priority] if options[:priority]
+          headers[:_AMQ_GROUP_ID]      = options[:group_name] if options[:group_name]
 
           [address, headers]
         end
@@ -34,9 +35,9 @@ module ManageIQ
           address = "topic/#{options[:service]}"
 
           headers = {:"destination-type" => 'MULTICAST'}
-          headers[:expires] = options[:expires_on].to_i * 1000 if options[:expires_on]
+          headers[:expires]            = options[:expires_on].to_i * 1000 if options[:expires_on]
           headers[:AMQ_SCHEDULED_TIME] = options[:deliver_on].to_i * 1000 if options[:deliver_on]
-          headers[:priority] = options[:priority] if options[:priority]
+          headers[:priority]           = options[:priority] if options[:priority]
 
           [address, headers]
         end

--- a/spec/manageiq/messaging/stomp/client_spec.rb
+++ b/spec/manageiq/messaging/stomp/client_spec.rb
@@ -57,9 +57,23 @@ describe ManageIQ::Messaging::Stomp::Client do
       expect(raw_client).to receive(:publish).with(
         'queue/s.uid',
         'p',
-        hash_including(:"destination-type" => 'ANYCAST', :message_type => 'm'))
+        hash_including(
+          :"destination-type" => 'ANYCAST',
+          :message_type       => 'm',
+          :priority           => 3,
+          :AMQ_SCHEDULED_TIME => Time.new(500).to_i * 1000,
+          :expires            => Time.new(600).to_i * 1000,
+          :_AMQ_GROUP_ID      => 'group1'))
 
-      subject.publish_message(:service => 's', :message => 'm', :affinity => 'uid', :payload => 'p')
+      subject.publish_message(
+        :service    => 's',
+        :message    => 'm',
+        :affinity   => 'uid',
+        :payload    => 'p',
+        :priority   => 3,
+        :deliver_on => Time.new(500),
+        :expires_on => Time.new(600),
+        :group_name => 'group1')
     end
 
     it 'sends a message without affinity to the queue' do


### PR DESCRIPTION
Queue messages with the same `group_name` will be consumed by the same consumer.

Allow to add `:group_name => <name>` to `client.publish_message(options)` option list.