### PR TITLE
rescue and log consumer errors

### DIFF
--- a/lib/manageiq/messaging/stomp/background_job.rb
+++ b/lib/manageiq/messaging/stomp/background_job.rb
@@ -8,8 +8,8 @@ module ManageIQ
           queue_name, headers = queue_for_subscribe(options)
 
           subscribe(queue_name, headers) do |msg|
-            ack(msg)
             begin
+              ack(msg)
               assert_options(msg.headers, ['class_name', 'message_type'])
 
               msg_options = decode_body(msg.headers, msg.body)
@@ -30,6 +30,9 @@ module ManageIQ
                   logger.error("Error encountered during <ActiveRecord::Base.connection.reconnect!> error:#{err.class.name}: #{err.message}")
                 end
               end
+            rescue => e
+              logger.error("Background job error: #{e.message}")
+              logger.error(e.backtrace.join("\n"))
             end
           end
         end

--- a/lib/manageiq/messaging/stomp/queue.rb
+++ b/lib/manageiq/messaging/stomp/queue.rb
@@ -25,18 +25,23 @@ module ManageIQ
 
           # for STOMP we can get message one at a time
           subscribe(queue_name, headers) do |msg|
-            sender = msg.headers['sender']
-            message_type = msg.headers['message_type']
-            message_body = decode_body(msg.headers, msg.body)
-            logger.info("Message received: queue(#{queue_name}), msg(#{payload_log(message_body)}), headers(#{msg.headers})")
+            begin
+              sender = msg.headers['sender']
+              message_type = msg.headers['message_type']
+              message_body = decode_body(msg.headers, msg.body)
+              logger.info("Message received: queue(#{queue_name}), msg(#{payload_log(message_body)}), headers(#{msg.headers})")
 
-            result = yield [ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, message_body, msg)]
-            logger.info("Message processed")
+              result = yield [ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, message_body, msg)]
+              logger.info("Message processed")
 
-            correlation_ref = msg.headers['correlation_id']
-            if correlation_ref
-              result = result.first if result.kind_of?(Array)
-              send_response(options[:service], correlation_ref, result)
+              correlation_ref = msg.headers['correlation_id']
+              if correlation_ref
+                result = result.first if result.kind_of?(Array)
+                send_response(options[:service], correlation_ref, result)
+              end
+            rescue => e
+              logger.error("Message processing error: #{e.message}")
+              logger.error(e.backtrace.join("\n"))
             end
           end
         end

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -16,14 +16,19 @@ module ManageIQ
           queue_name, headers = topic_for_subscribe(options)
 
           subscribe(queue_name, headers) do |event|
-            ack(event)
+            begin
+              ack(event)
 
-            sender = event.headers['sender']
-            event_type = event.headers['event_type']
-            event_body = decode_body(event.headers, event.body)
-            logger.info("Event received: queue(#{queue_name}), event(#{event_body}), headers(#{event.headers})")
-            yield sender, event_type, event_body
-            logger.info("Event processed")
+              sender = event.headers['sender']
+              event_type = event.headers['event_type']
+              event_body = decode_body(event.headers, event.body)
+              logger.info("Event received: queue(#{queue_name}), event(#{event_body}), headers(#{event.headers})")
+              yield sender, event_type, event_body
+              logger.info("Event processed")
+            rescue => e
+              logger.error("Event processing error: #{e.message}")
+              logger.error(e.backtrace.join("\n"))
+            end
           end
         end
       end


### PR DESCRIPTION
For STOMP the stomp gem uses a dedicated thread for subscribing and consuming messages. If the user consumer block raises an error it will cause the thread to die silently without the main/worker thread knowing. The minimum we must do it to rescue any error and log it. Beyond that we can have three options:

1. Re-reaise the error so the consumer thread will die. It is up to the worker thread whether to abort by setting `Thread::abort_on_exception`

2. Write to an error flag and allow the consumer thread to die. The worker thread will periodically check for the error flag and decide how to proceed.

3. Consume the error and let the consumer to continue.

I prefer option 2, but it requires that we add a new healthiness check method to the client interface. I will postpone the decision how to present it until we are more familiar with qpid-proton and understand whether we have similar problem there. This PR takes option 3 as a possible temporary solution, but the error logging is needed always.  