### PR TITLE
Make each message durable

### DIFF
--- a/lib/manageiq/messaging/stomp/common.rb
+++ b/lib/manageiq/messaging/stomp/common.rb
@@ -13,7 +13,7 @@ module ManageIQ
           affinity = options[:affinity] || 'none'
           address = "queue/#{options[:service]}.#{affinity}"
 
-          headers = {:"destination-type" => 'ANYCAST'}
+          headers = {:"destination-type" => 'ANYCAST', :persistent => true}
           headers[:expires]            = options[:expires_on].to_i * 1000 if options[:expires_on]
           headers[:AMQ_SCHEDULED_TIME] = options[:deliver_on].to_i * 1000 if options[:deliver_on]
           headers[:priority]           = options[:priority] if options[:priority]
@@ -34,7 +34,7 @@ module ManageIQ
         def topic_for_publish(options)
           address = "topic/#{options[:service]}"
 
-          headers = {:"destination-type" => 'MULTICAST'}
+          headers = {:"destination-type" => 'MULTICAST', :persistent => true}
           headers[:expires]            = options[:expires_on].to_i * 1000 if options[:expires_on]
           headers[:AMQ_SCHEDULED_TIME] = options[:deliver_on].to_i * 1000 if options[:deliver_on]
           headers[:priority]           = options[:priority] if options[:priority]

--- a/spec/manageiq/messaging/stomp/client_spec.rb
+++ b/spec/manageiq/messaging/stomp/client_spec.rb
@@ -63,7 +63,8 @@ describe ManageIQ::Messaging::Stomp::Client do
           :priority           => 3,
           :AMQ_SCHEDULED_TIME => Time.new(500).to_i * 1000,
           :expires            => Time.new(600).to_i * 1000,
-          :_AMQ_GROUP_ID      => 'group1'))
+          :_AMQ_GROUP_ID      => 'group1',
+          :persistent         => true))
 
       subject.publish_message(
         :service    => 's',
@@ -128,7 +129,8 @@ describe ManageIQ::Messaging::Stomp::Client do
           :"destination-type" => 'ANYCAST',
           :message_type       => 'my_method',
           :class_name         => 'MyClass',
-          :encoding           => "json"))
+          :encoding           => "json",
+          :persistent         => true))
 
       subject.publish_message(
         :service    => 's',
@@ -142,11 +144,12 @@ describe ManageIQ::Messaging::Stomp::Client do
       expect(raw_client).to receive(:publish).with(
         'queue/s.uid',
         "string",
-        {
+        hash_including(
           :"destination-type" => 'ANYCAST',
           :message_type       => 'my_method',
           :class_name         => 'MyClass',
-        })
+          :persistent         => true
+        ))
 
       subject.publish_message(
         :service    => 's',


### PR DESCRIPTION
By default messages are durable. Any undelivered messages are lost if the server interrupts or reboots.
This work is to make each message durable.