### PR TITLE
Support Kafka publish/subscribe_topic

### DIFF
--- a/lib/manageiq/messaging.rb
+++ b/lib/manageiq/messaging.rb
@@ -6,6 +6,9 @@ require 'manageiq/messaging/null_logger'
 
 module ManageIQ
   module Messaging
+    autoload :Stomp, 'manageiq/messaging/stomp'
+    autoload :Kafka, 'manageiq/messaging/kafka'
+
     class << self
       attr_writer :logger
     end

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -1,8 +1,6 @@
 module ManageIQ
   module Messaging
     class Client
-      require 'manageiq/messaging/stomp/client'
-
       # Open or create a connection to the message broker
       # @param options [Hash] the connection options
       # @return [Client, nil] the client object if no block is given

--- a/lib/manageiq/messaging/kafka.rb
+++ b/lib/manageiq/messaging/kafka.rb
@@ -1,0 +1,7 @@
+module ManageIQ
+  module Messaging
+    module Kafka
+      autoload :Client, 'manageiq/messaging/kafka/client'
+    end
+  end
+end

--- a/lib/manageiq/messaging/kafka/background_job.rb
+++ b/lib/manageiq/messaging/kafka/background_job.rb
@@ -1,0 +1,13 @@
+module ManageIQ
+  module Messaging
+    module Kafka
+      module BackgroundJob
+        private
+
+        def subscribe_background_job_impl(_options)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -1,0 +1,60 @@
+module ManageIQ
+  module Messaging
+    module Kafka
+      class Client < ManageIQ::Messaging::Client
+        require 'kafka'
+        require 'manageiq/messaging/kafka/common'
+        require 'manageiq/messaging/kafka/queue'
+        require 'manageiq/messaging/kafka/background_job'
+        require 'manageiq/messaging/kafka/topic'
+
+        include Common
+        include Queue
+        include BackgroundJob
+        include Topic
+
+        private *delegate(:subscribe, :unsubscribe, :publish, :to => :kafka_client)
+        delegate :close, :to => :kafka_client
+
+        attr_accessor :encoding
+
+        def ack(*_args)
+        end
+
+        def close
+          @consumer.try(:stop)
+          @consumer = nil
+
+          @producer.try(:shutdown)
+          @producer = nil
+
+          kafka_client.close
+          @kafka_client = nil
+        end
+
+        private
+
+        attr_reader :kafka_client
+
+        # @options options :host
+        # @options options :hosts (array)
+        # @options options :port
+        # @options options :group_ref
+        # @options options :client_ref (optional)
+        # @options options :encoding (default to 'yaml')
+        def initialize(options)
+          hosts = Array(options[:hosts]) + Array(options[:host])
+          hosts.collect! { |host| "#{host}:#{options[:port]}" }
+
+          @encoding = options[:encoding] || 'yaml'
+          require "json" if @encoding == "json"
+
+          connection_opts = {}
+          connection_opts[:client_id] = options[:client_ref] if options[:client_ref]
+
+          @kafka_client = ::Kafka.new(hosts, connection_opts)
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -43,7 +43,7 @@ module ManageIQ
         # @options options :client_ref (optional)
         # @options options :encoding (default to 'yaml')
         def initialize(options)
-          hosts = Array(options[:hosts]) + Array(options[:host])
+          hosts = Array(options[:hosts] || options[:host])
           hosts.collect! { |host| "#{host}:#{options[:port]}" }
 
           @encoding = options[:encoding] || 'yaml'

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -1,0 +1,121 @@
+module ManageIQ
+  module Messaging
+    module Kafka
+      module Common
+        GROUP_FOR_QUEUE_MESSAGES = 'manageiq_messaging_queue_group'.freeze
+
+        private
+
+        def producer
+          @producer ||= kafka_client.producer
+        end
+
+        def topic_consumer(group_ref)
+          @consumer.try(:stop) unless @group_ref == group_ref
+          @group_ref = group_ref
+          @topic_consumer ||= kafka_client.consumer(:group_id => group_ref)
+        end
+
+        def queue_consumer
+          # all queue consumers join the same group so that each message can be processed by one and only one consumer
+          @queue_consumer ||= kafka_client.consumer(:group_id => GROUP_FOR_QUEUE_MESSAGES)
+        end
+
+        trap("TERM") do
+          @consumer.try(:stop)
+          @consumer = nil
+        end
+
+        def raw_publish(commit, body, options)
+          producer.produce(encode_body(body), options)
+          producer.deliver_messages if commit
+          logger.info("Published to topic(#{options[:topic]}), msg(#{payload_log(body[:data].inspect)})")
+        end
+
+        def queue_for_publish(options)
+          body, kafka_opts = for_publish(options)
+          body[:message_type] = options[:message] if options[:message]
+          body[:class_name] = options[:class_name] if options[:class_name]
+
+          [body, kafka_opts]
+        end
+
+        def topic_for_publish(options)
+          body, kafka_opts = for_publish(options)
+          body[:event_type] = options[:event] if options[:event]
+
+          [body, kafka_opts]
+        end
+
+        def for_publish(options)
+          kafka_opts = {:topic => options[:service]}
+          kafka_opts[:partition_key] = options[:affinity] if options[:affinity]
+
+          body = {:payload => options[:payload] || ''}
+          body[:sender] = options[:sender] if options[:sender]
+
+          [body, kafka_opts]
+        end
+
+        def process_queue_message(queue, message)
+          queue_message = decode_body(message.value)
+          sender, message_type, class_name, payload = parse_message(queue_message)
+          logger.info("Message received: queue(#{queue}), message(#{payload_log(payload)}), sender(#{sender}), type(#{message_type})")
+          [sender, message_type, class_name, payload]
+        end
+
+        def process_topic_message(topic, message)
+          begin
+            event = decode_body(message.value)
+            sender, event_type, payload = parse_event(event)
+            logger.info("Event received: topic(#{topic}), event(#{payload_log(payload)}), sender(#{sender}), type(#{event_type})")
+            yield sender, event_type, payload
+            logger.info("Event processed")
+          rescue StandardError => e
+            logger.error("Event processing error: #{e.message}")
+            logger.error(e.backtrace.join("\n"))
+          end
+        end
+
+        def parse_message(message)
+          return [nil, nil, nil, message] unless message.kind_of?(Hash)
+          message.values_at('sender', 'message_type', 'class_name', 'payload')
+        end
+
+        def parse_event(event)
+          return [nil, nil, event] unless event.kind_of?(Hash)
+          event.values_at('sender', 'event_type', 'payload')
+        end
+
+        def encode_body(body)
+          body[:encoding] = encoding
+          case encoding
+          when 'json'
+            JSON.generate(body)
+          when 'yaml'
+            body.stringify_keys.to_yaml
+          else
+            raise "unknown message encoding: #{encoding}"
+          end
+        end
+
+        def decode_body(raw_body)
+          if raw_body.lstrip.start_with?('{')
+            parsed = JSON.parse(raw_body)
+            return raw_body unless parsed.key?('payload') && parsed['encoding'] == 'json'
+          else
+            parsed = YAML.safe_load(raw_body)
+            return raw_body unless parsed.key?('payload') && parsed['encoding'] == 'yaml'
+          end
+          parsed
+        rescue StandardError
+          raw_body
+        end
+
+        def payload_log(payload)
+          payload.to_s[0..100]
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -1,0 +1,39 @@
+module ManageIQ
+  module Messaging
+    module Kafka
+      module Queue
+        def publish_message_impl(options, &_block)
+          raise ArgumentError, "Kafka messaging implementation does not take a block" if block_given?
+          raw_publish(true, *queue_for_publish(options))
+        end
+
+        def publish_messages_impl(messages)
+          messages.each { |msg_options| raw_publish(false, *queue_for_publish(msg_options)) }
+          producer.deliver_messages
+        end
+
+        def subscribe_messages_impl(options)
+          topic = options[:service]
+
+          consumer = queue_consumer
+          consumer.subscribe(topic)
+          consumer.each_batch do |batch|
+            logger.info("Batch message received: queue(#{topic})")
+            begin
+              messages = batch.messages.collect do |message|
+                sender, message_type, _class_name, payload = process_queue_message(topic, message)
+                ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, payload, nil)
+              end
+
+              yield messages
+            rescue StandardError => e
+              logger.error("Event processing error: #{e.message}")
+              logger.error(e.backtrace.join("\n"))
+            end
+            logger.info("Batch message processed")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -2,7 +2,7 @@ module ManageIQ
   module Messaging
     module Kafka
       module Queue
-        def publish_message_impl(options, &_block)
+        def publish_message_impl(options)
           raise ArgumentError, "Kafka messaging implementation does not take a block" if block_given?
           raw_publish(true, *queue_for_publish(options))
         end

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -1,0 +1,28 @@
+module ManageIQ
+  module Messaging
+    module Kafka
+      module Topic
+        private
+
+        def publish_topic_impl(options)
+          raw_publish(true, *topic_for_publish(options))
+        end
+
+        def subscribe_topic_impl(options, &block)
+          topic = options[:service]
+          persist_ref = options[:persist_ref]
+
+          if persist_ref
+            consumer = topic_consumer(persist_ref)
+            consumer.subscribe(topic, :start_from_beginning => false)
+            consumer.each_message { |message| process_topic_message(topic, message, &block) }
+          else
+            kafka_client.each_message(:topic => topic, :start_from_beginning => false) do |message|
+              process_topic_message(topic, message, &block)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/stomp.rb
+++ b/lib/manageiq/messaging/stomp.rb
@@ -1,0 +1,7 @@
+module ManageIQ
+  module Messaging
+    module Stomp
+      autoload :Client, 'manageiq/messaging/stomp/client'
+    end
+  end
+end

--- a/manageiq-messaging.gemspec
+++ b/manageiq-messaging.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'activesupport', '>= 4.2.2'
+  spec.add_dependency 'ruby-kafka', '>=0.7.0'
   spec.add_dependency 'stomp', '>= 1.4.4'
 
   spec.add_development_dependency "bundler", "~> 1.13"

--- a/spec/manageiq/messaging/kafka/client_spec.rb
+++ b/spec/manageiq/messaging/kafka/client_spec.rb
@@ -1,0 +1,135 @@
+require "spec_helper"
+
+describe ManageIQ::Messaging::Kafka::Client do
+  let(:producer)   { double(:producer) }
+  let(:raw_client) { double(:kafka_client, :producer => producer) }
+
+  subject do
+    expect(::Kafka).to receive(:new).and_return(raw_client)
+    described_class.new(:host => 'localhost', :port => 1234)
+  end
+
+  describe '#initialize' do
+    it 'creates a client connects to a single host' do
+      expect(::Kafka).to receive(:new).with(['localhost:1234'], :client_id => 'my-ref')
+
+      described_class.new(
+        :protocol   => 'Kafka',
+        :host       => 'localhost',
+        :port       => 1234,
+        :client_ref => 'my-ref'
+      )
+    end
+
+    it 'creates a client connects to a cluster' do
+      expect(::Kafka).to receive(:new).with(%w(host1:1234 host2:1234), :client_id => 'my-ref')
+
+      described_class.new(
+        :hosts      => %w(host1 host2),
+        :port       => 1234,
+        :client_ref => 'my-ref'
+      )
+    end
+  end
+
+  describe '#publish_topic' do
+    it 'sends the message to the topic' do
+      expect(producer).to receive(:deliver_messages)
+      expect(producer).to receive(:produce).with(
+        "---\npayload: p\nevent_type: e\nencoding: yaml\n",
+        hash_including(:topic => 's', :partition_key => 'a')
+      )
+
+      subject.publish_topic(:service => 's', :event => 'e', :payload => 'p', :affinity => 'a')
+    end
+  end
+
+  describe '#subscribe_topic' do
+    let(:consumer) { double(:topic_consumer) }
+
+    it 'listens to the topic with persist_ref' do
+      expect(raw_client).to receive(:consumer).with(:group_id => 'pid').and_return(consumer)
+      expect(consumer).to receive(:subscribe).with('s', :start_from_beginning => false)
+      expect(consumer).to receive(:each_message)
+
+      subject.subscribe_topic(:service => 's', :persist_ref => 'pid') { |_a, _b, _c| nil }
+    end
+
+    it 'listens to the topic without persist_ref' do
+      expect(raw_client).to receive(:each_message).with(:topic => 's', :start_from_beginning => false)
+
+      subject.subscribe_topic(:service => 's') { |_a, _b, _c| nil }
+    end
+  end
+
+  describe '#publish_message' do
+    it 'sends a regular message to the queue' do
+      expect(producer).to receive(:deliver_messages)
+      expect(producer).to receive(:produce).with(
+        "---\npayload: p\nmessage_type: m\nencoding: yaml\n",
+        hash_including(:topic => 's', :partition_key => 'uid')
+      )
+
+      subject.publish_message(
+        :service    => 's',
+        :message    => 'm',
+        :affinity   => 'uid',
+        :payload    => 'p')
+    end
+
+    it 'sends a message without affinity to the queue' do
+      expect(producer).to receive(:deliver_messages)
+      expect(producer).to receive(:produce).with(
+        "---\npayload: p\nsender: me\nmessage_type: m\nencoding: yaml\n",
+        :topic => 's'
+      )
+
+      subject.publish_message(:service => 's', :message => 'm', :payload => 'p', :sender => 'me')
+    end
+  end
+
+  describe '#publish_message with json encoder' do
+    subject do
+      expect(::Kafka).to receive(:new).and_return(raw_client)
+      described_class.new(:host => 'localhost', :port => 1234, :encoding => "json")
+    end
+
+    it 'sends alternative encoding to the queue' do
+      expect(producer).to receive(:deliver_messages)
+      expect(producer).to receive(:produce).with(
+        "{\"payload\":{\"instance_id\":1,\"args\":[\"arg1\",2]},\"message_type\":\"my_method\",\"class_name\":\"MyClass\",\"encoding\":\"json\"}",
+        hash_including(:topic => 's', :partition_key => 'uid')
+      )
+
+      subject.publish_message(
+        :service    => 's',
+        :class_name => 'MyClass',
+        :message    => 'my_method',
+        :affinity   => 'uid',
+        :payload    => { :instance_id => 1, :args => ['arg1', 2] })
+    end
+  end
+
+  describe '#subscribe_messages' do
+    let(:consumer) { double(:message_consumer) }
+
+    it 'listens to the queue with built-in group_id' do
+      expect(raw_client).to receive(:consumer).with(:group_id => described_class::GROUP_FOR_QUEUE_MESSAGES).and_return(consumer)
+      expect(consumer).to receive(:subscribe).with('s')
+      expect(consumer).to receive(:each_batch)
+
+      subject.subscribe_messages(:service => 's', :affinity => 'uid') { |messages| nil }
+    end
+  end
+
+  describe '#publish_messages' do
+    it 'sends to the queue one by one but delivers once' do
+      expect(producer).to receive(:produce).with("---\npayload: p1\nmessage_type: m\nencoding: yaml\n", :topic => 's')
+      expect(producer).to receive(:produce).with("---\npayload: p2\nmessage_type: m\nencoding: yaml\n", :topic => 's')
+      expect(producer).to receive(:deliver_messages).once
+      subject.publish_messages([
+        {:service => 's', :message => 'm', :payload => 'p1' },
+        {:service => 's', :message => 'm', :payload => 'p2' }])
+    end
+  end
+end


### PR DESCRIPTION
This work adds Kafka as one of supported underlying messaging system.

This initial work only support broadcast/subscribe (topic) model. Point-to-point messaging (queue) implementation may be added in the future. However p2p messaging can be already done by using the implemented broadcast/subscribe model.

~~To use the client as a subscriber, the initialization options must include `group_ref`~~. If multiple clients join different groups and subscribe to the topic, every group will receive all the messages. This is the broadcast/subscribe model.

If there is only one group for a given topic, it works like a p2p communication. If multiple clients join the same group, the clients will consume messages in a load-balanced way.

### Update ###
With updated commit, both p2p and broadcast are now supported, and they behalf the same way as defined in base api.
For p2p (queue) type, if multiple clients join the same queue, they consume the messages in a load balancing way.
For broadcast (topic) type, if multiple clients join the topic without a `persist_ref`, they all receive a copy of every message. If clients join the topic with the same `persist_ref`, they will consume messages in a load balancing way.
