### PR TITLE
A few refactorings for Kafka

### DIFF
--- a/lib/manageiq/messaging/common.rb
+++ b/lib/manageiq/messaging/common.rb
@@ -1,0 +1,34 @@
+module ManageIQ
+  module Messaging
+    module Common
+      def encode_body(headers, body)
+        return body if body.kind_of?(String)
+        headers[:encoding] = encoding
+        case encoding
+        when "json"
+          JSON.generate(body)
+        when "yaml"
+          body.to_yaml
+        else
+          raise "unknown message encoding: #{encoding}"
+        end
+      end
+
+      def decode_body(headers, raw_body)
+        return raw_body unless headers.kind_of?(Hash)
+        case headers["encoding"]
+        when "json"
+          JSON.parse(raw_body)
+        when "yaml"
+          YAML.safe_load(raw_body)
+        else
+          raw_body
+        end
+      end
+
+      def payload_log(payload)
+        payload.to_s[0..100]
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -39,9 +39,9 @@ module ManageIQ
         # @options options :host
         # @options options :hosts (array)
         # @options options :port
-        # @options options :group_ref
         # @options options :client_ref (optional)
         # @options options :encoding (default to 'yaml')
+        # @options options :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_key, :sasl_gssapi_principal, :sasl_gssapi_keytab, :sasl_plain_username, :sasl_plain_password, :sasl_scram_username, :sasl_scram_password, :sasl_scram_mechanism
         def initialize(options)
           hosts = Array(options[:hosts] || options[:host])
           hosts.collect! { |host| "#{host}:#{options[:port]}" }
@@ -51,6 +51,8 @@ module ManageIQ
 
           connection_opts = {}
           connection_opts[:client_id] = options[:client_ref] if options[:client_ref]
+
+          connection_opts.merge!(options.slice(:ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_key, :sasl_gssapi_principal, :sasl_gssapi_keytab, :sasl_plain_username, :sasl_plain_password, :sasl_scram_username, :sasl_scram_password, :sasl_scram_mechanism))
 
           @kafka_client = ::Kafka.new(hosts, connection_opts)
         end

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -2,6 +2,9 @@ module ManageIQ
   module Messaging
     module Kafka
       module Common
+        require 'manageiq/messaging/common'
+        include ManageIQ::Messaging::Common
+
         GROUP_FOR_QUEUE_MESSAGES = 'manageiq_messaging_queue_group'.freeze
 
         private
@@ -10,10 +13,12 @@ module ManageIQ
           @producer ||= kafka_client.producer
         end
 
-        def topic_consumer(group_ref)
-          @consumer.try(:stop) unless @group_ref == group_ref
-          @group_ref = group_ref
-          @topic_consumer ||= kafka_client.consumer(:group_id => group_ref)
+        def topic_consumer(persist_ref)
+          # persist_ref enables consumer to receive messages sent when consumer is temporarily offline
+          # it also enables consumers to do load balancing when multiple consumers join the with the same ref.
+          @consumer.try(:stop) unless @persist_ref == persist_ref
+          @persist_ref = persist_ref
+          @topic_consumer ||= kafka_client.consumer(:group_id => persist_ref)
         end
 
         def queue_consumer
@@ -27,47 +32,55 @@ module ManageIQ
         end
 
         def raw_publish(commit, body, options)
-          producer.produce(encode_body(body), options)
+          producer.produce(encode_body(options[:headers], body), options)
           producer.deliver_messages if commit
-          logger.info("Published to topic(#{options[:topic]}), msg(#{payload_log(body[:data].inspect)})")
+          logger.info("Published to topic(#{options[:topic]}), msg(#{payload_log(body.inspect)})")
         end
 
         def queue_for_publish(options)
           body, kafka_opts = for_publish(options)
-          body[:message_type] = options[:message] if options[:message]
-          body[:class_name] = options[:class_name] if options[:class_name]
+          kafka_opts[:headers][:message_type] = options[:message] if options[:message]
+          kafka_opts[:headers][:class_name] = options[:class_name] if options[:class_name]
 
           [body, kafka_opts]
         end
 
         def topic_for_publish(options)
           body, kafka_opts = for_publish(options)
-          body[:event_type] = options[:event] if options[:event]
+          kafka_opts[:headers][:event_type] = options[:event] if options[:event]
 
           [body, kafka_opts]
         end
 
         def for_publish(options)
-          kafka_opts = {:topic => options[:service]}
-          kafka_opts[:partition_key] = options[:affinity] if options[:affinity]
+          kafka_opts = {:topic => address(options), :headers => {}}
+          kafka_opts[:partition_key] = options[:group_name] if options[:group_name]
+          kafka_opts[:headers][:sender] = options[:sender] if options[:sender]
 
-          body = {:payload => options[:payload] || ''}
-          body[:sender] = options[:sender] if options[:sender]
+          body = options[:payload] || ''
 
           [body, kafka_opts]
         end
 
+        def address(options)
+          if options[:affinity]
+            "#{options[:service]}.#{options[:affinity]}"
+          else
+            options[:service]
+          end
+        end
+
         def process_queue_message(queue, message)
-          queue_message = decode_body(message.value)
-          sender, message_type, class_name, payload = parse_message(queue_message)
+          payload = decode_body(message.headers, message.value)
+          sender, message_type, class_name = parse_message_headers(message.headers)
           logger.info("Message received: queue(#{queue}), message(#{payload_log(payload)}), sender(#{sender}), type(#{message_type})")
           [sender, message_type, class_name, payload]
         end
 
         def process_topic_message(topic, message)
           begin
-            event = decode_body(message.value)
-            sender, event_type, payload = parse_event(event)
+            payload = decode_body(message.headers, message.value)
+            sender, event_type = parse_event_headers(message.headers)
             logger.info("Event received: topic(#{topic}), event(#{payload_log(payload)}), sender(#{sender}), type(#{event_type})")
             yield sender, event_type, payload
             logger.info("Event processed")
@@ -77,43 +90,14 @@ module ManageIQ
           end
         end
 
-        def parse_message(message)
-          return [nil, nil, nil, message] unless message.kind_of?(Hash)
-          message.values_at('sender', 'message_type', 'class_name', 'payload')
+        def parse_message_headers(headers)
+          return [nil, nil, nil] unless headers.kind_of?(Hash)
+          headers.values_at('sender', 'message_type', 'class_name')
         end
 
-        def parse_event(event)
-          return [nil, nil, event] unless event.kind_of?(Hash)
-          event.values_at('sender', 'event_type', 'payload')
-        end
-
-        def encode_body(body)
-          body[:encoding] = encoding
-          case encoding
-          when 'json'
-            JSON.generate(body)
-          when 'yaml'
-            body.stringify_keys.to_yaml
-          else
-            raise "unknown message encoding: #{encoding}"
-          end
-        end
-
-        def decode_body(raw_body)
-          if raw_body.lstrip.start_with?('{')
-            parsed = JSON.parse(raw_body)
-            return raw_body unless parsed.key?('payload') && parsed['encoding'] == 'json'
-          else
-            parsed = YAML.safe_load(raw_body)
-            return raw_body unless parsed.key?('payload') && parsed['encoding'] == 'yaml'
-          end
-          parsed
-        rescue StandardError
-          raw_body
-        end
-
-        def payload_log(payload)
-          payload.to_s[0..100]
+        def parse_event_headers(headers)
+          return [nil, nil] unless headers.kind_of?(Hash)
+          headers.values_at('sender', 'event_type')
         end
       end
     end

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -13,7 +13,7 @@ module ManageIQ
         end
 
         def subscribe_messages_impl(options)
-          topic = options[:service]
+          topic = address(options)
 
           consumer = queue_consumer
           consumer.subscribe(topic)

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -9,7 +9,7 @@ module ManageIQ
         end
 
         def subscribe_topic_impl(options, &block)
-          topic = options[:service]
+          topic = address(options)
           persist_ref = options[:persist_ref]
 
           if persist_ref

--- a/lib/manageiq/messaging/stomp/common.rb
+++ b/lib/manageiq/messaging/stomp/common.rb
@@ -2,6 +2,9 @@ module ManageIQ
   module Messaging
     module Stomp
       module Common
+        require 'manageiq/messaging/common'
+        include ManageIQ::Messaging::Common
+
         private
 
         def raw_publish(address, body, headers)
@@ -49,34 +52,6 @@ module ManageIQ
           headers[:"durable-subscription-name"] = options[:persist_ref] if options[:persist_ref]
 
           [queue_name, headers]
-        end
-
-        def encode_body(headers, body)
-          return body if body.kind_of?(String)
-          headers[:encoding] = encoding
-          case encoding
-          when "json"
-            JSON.generate(body)
-          when "yaml"
-            body.to_yaml
-          else
-            raise "unknown message encoding: #{encoding}"
-          end
-        end
-
-        def decode_body(headers, raw_body)
-          case headers["encoding"]
-          when "json"
-            JSON.parse(raw_body)
-          when "yaml"
-            YAML.load(raw_body)
-          else
-            raw_body
-          end
-        end
-
-        def payload_log(payload)
-          payload.to_s[0..100]
         end
 
         def send_response(service, correlation_ref, result)


### PR DESCRIPTION
- Create separate topic if affinity is needed
- Use `:group_name` to group messages
- Move metadata to headers
- Move shared code to common

@agrare please review and test. For your existing code you only need to change key `:affinity` to `:group_name` in `options`. 
`group_name` is already used in the Artemis for the same purpose. We'd better to use the same key.