### PR TITLE
Default auto commit subscribed messages, but allow to be turned off

### DIFF
--- a/examples/message.rb
+++ b/examples/message.rb
@@ -23,7 +23,7 @@ class ProducerConsumer < Common
       puts "produced 5 messages"
 
       puts "consumer"
-      client.subscribe_messages(:service => 'ems_operation', :affinity => 'ems_amazon1') do |messages|
+      client.subscribe_messages(:service => 'ems_operation', :affinity => 'ems_amazon1', :auto_ack => false) do |messages|
         messages.each do |msg|
           do_stuff(msg)
           client.ack(msg.ack_ref)

--- a/lib/manageiq/messaging/common.rb
+++ b/lib/manageiq/messaging/common.rb
@@ -31,6 +31,10 @@ module ManageIQ
       def payload_log(payload)
         payload.to_s[0..100]
       end
+
+      def auto_ack?(options)
+        options.key?(:auto_ack) ? options[:auto_ack] : true
+      end
     end
   end
 end

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -53,12 +53,16 @@ module ManageIQ
 
         attr_accessor :encoding
 
-        def ack(*_args)
+        def ack(ack_ref)
+          @queue_consumer.try(:mark_message_as_processed, ack_ref)
+          @topic_consumer.try(:mark_message_as_processed, ack_ref)
         end
 
         def close
-          @consumer.try(:stop)
-          @consumer = nil
+          @topic_consumer.try(:stop)
+          @topic_consumer = nil
+          @queue_consumer.try(:stop)
+          @queue_consumer = nil
 
           @producer.try(:shutdown)
           @producer = nil

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -19,12 +19,12 @@ module ManageIQ
 
           consumer = queue_consumer
           consumer.subscribe(topic)
-          consumer.each_batch do |batch|
+          consumer.each_batch(:automatically_mark_as_processed => auto_ack?(options)) do |batch|
             logger.info("Batch message received: queue(#{topic})")
             begin
               messages = batch.messages.collect do |message|
                 sender, message_type, _class_name, payload = process_queue_message(topic, message)
-                ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, payload, nil)
+                ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, payload, message)
               end
 
               yield messages

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -15,7 +15,9 @@ module ManageIQ
           if persist_ref
             consumer = topic_consumer(persist_ref)
             consumer.subscribe(topic, :start_from_beginning => false)
-            consumer.each_message { |message| process_topic_message(topic, message, &block) }
+            consumer.each_message(:automatically_mark_as_processed => auto_ack?(options)) do |message|
+              process_topic_message(topic, message, &block)
+            end
           else
             kafka_client.each_message(:topic => topic, :start_from_beginning => false) do |message|
               process_topic_message(topic, message, &block)

--- a/lib/manageiq/messaging/stomp/queue.rb
+++ b/lib/manageiq/messaging/stomp/queue.rb
@@ -28,6 +28,8 @@ module ManageIQ
           # for STOMP we can get message one at a time
           subscribe(queue_name, headers) do |msg|
             begin
+              ack(msg) if auto_ack?(options)
+
               sender = msg.headers['sender']
               message_type = msg.headers['message_type']
               message_body = decode_body(msg.headers, msg.body)

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -17,13 +17,13 @@ module ManageIQ
 
           subscribe(queue_name, headers) do |event|
             begin
-              ack(event)
+              ack(event) if auto_ack?(options)
 
               sender = event.headers['sender']
               event_type = event.headers['event_type']
               event_body = decode_body(event.headers, event.body)
               logger.info("Event received: queue(#{queue_name}), event(#{event_body}), headers(#{event.headers})")
-              yield sender, event_type, event_body
+              yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, event_body, event)
               logger.info("Event processed")
             rescue => e
               logger.error("Event processing error: #{e.message}")


### PR DESCRIPTION
This work allows to configure how to commit/ack subscribed messages.

Previously all Kafka messages are always auto committed. Artemis STOMP messages are auto committed for event/topic type; manually committed for message type.

Now any message by default is always auto committed. This is feature is turned off if subscribe `options[:auto_ack]` is `false`. Then the user block can decide where to ack the commit, before or after the message is processed.
