### PR TITLE
Allow to pass max_bytes to each_batch method

### DIFF
--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -27,6 +27,9 @@ module ManageIQ
       # Kafka specific +subscribe_topic+ options:
       # * :persist_ref (Used as Kafka group_id)
       #
+      # Kafka specific +subscribe_messages+ options:
+      # * :max_bytes (Max batch size to read, default is 10Mb)
+      #
       # Without +:persist_ref+ every topic subscriber receives a copy of each message
       # only when they are active. If multiple topic subscribers join with the same
       # +:persist_ref+, each message is consumed by only one of the subscribers. This

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -17,9 +17,13 @@ module ManageIQ
         def subscribe_messages_impl(options)
           topic = address(options)
 
+          batch_options = {}
+          batch_options[:automatically_mark_as_processed] = auto_ack?(options)
+          batch_options[:max_bytes] = options[:max_bytes] if options.key?(:max_bytes)
+
           consumer = queue_consumer
           consumer.subscribe(topic)
-          consumer.each_batch(:automatically_mark_as_processed => auto_ack?(options)) do |batch|
+          consumer.each_batch(batch_options) do |batch|
             logger.info("Batch message received: queue(#{topic})")
             begin
               messages = batch.messages.collect do |message|

--- a/spec/manageiq/messaging/kafka/client_spec.rb
+++ b/spec/manageiq/messaging/kafka/client_spec.rb
@@ -131,6 +131,14 @@ describe ManageIQ::Messaging::Kafka::Client do
 
       subject.subscribe_messages(:service => 's', :affinity => 'uid', :auto_ack => auto_ack) { |messages| nil }
     end
+
+    it 'passes max_bytes to each_batch' do
+      expect(raw_client).to receive(:consumer).with(:group_id => described_class::GROUP_FOR_QUEUE_MESSAGES).and_return(consumer)
+      expect(consumer).to receive(:subscribe).with('s.uid')
+      expect(consumer).to receive(:each_batch).with(:automatically_mark_as_processed => auto_ack, :max_bytes => 500000)
+
+      subject.subscribe_messages(:service => 's', :affinity => 'uid', :auto_ack => auto_ack, :max_bytes => 500000) { |messages| nil }
+    end
   end
 
   describe '#publish_messages' do


### PR DESCRIPTION
The default value of 10MB is too big, it's causing our app to
shoot to 400-500MB.