### PR TITLE
Add an #ack method to ReceivedMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This is the one-to-one publish/subscribe pattern. Multiple subscribers can subsc
   client.subscribe_messages(:service => 'ems_operation', :affinity => 'ems_amazon1', :auto_ack => false) do |messages|
     messages.each do |msg|
       # do stuff with msg.message and msg.payload
-      client.ack(msg.ack_ref)
+      msg.ack
     end
   end
 

--- a/examples/message.rb
+++ b/examples/message.rb
@@ -26,7 +26,7 @@ class ProducerConsumer < Common
       client.subscribe_messages(:service => 'ems_operation', :affinity => 'ems_amazon1', :auto_ack => false) do |messages|
         messages.each do |msg|
           do_stuff(msg)
-          client.ack(msg.ack_ref)
+          msg.ack
         end
       end
       sleep(5)

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -106,9 +106,9 @@ module ManageIQ
       #       msg.sender
       #       msg.message
       #       msg.payload
-      #       msg.ack_ref #used to ack the message
+      #       msg.ack_ref
       #
-      #       client.ack(msg.ack_ref) # needed only when options[:auto_ack] is false
+      #       msg.ack # needed only when options[:auto_ack] is false
       #       # process the message
       #     end
       #   end
@@ -122,7 +122,7 @@ module ManageIQ
       # message is proccessed. Any un-acked message will be redelivered to next subscriber
       # AFTER the current subscriber disconnects normally or abnormally (e.g. crashed).
       #
-      # To ack a message call +ack+(+msg.ack_ref+)
+      # To ack a message call +msg.ack+
       def subscribe_messages(options, &block)
         raise "A block is required" unless block_given?
         assert_options(options, [:service])
@@ -189,9 +189,9 @@ module ManageIQ
       #     msg.sender
       #     msg.message
       #     msg.payload
-      #     msg.ack_ref #used to ack the message
+      #     msg.ack_ref
       #
-      #     client.ack(msg.ack_ref) # needed only when options[:auto_ack] is false
+      #     msg.ack # needed only when options[:auto_ack] is false
       #     # process the message
       #   end
       #
@@ -204,7 +204,7 @@ module ManageIQ
       # message is proccessed. Any un-acked message will be redelivered to next subscriber
       # AFTER the current subscriber disconnects normally or abnormally (e.g. crashed).
       #
-      # To ack a message call +ack+(+msg.ack_ref+)
+      # To ack a message call +msg.ack+
       def subscribe_topic(options, &block)
         raise "A block is required" unless block_given?
         assert_options(options, [:service])

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -86,7 +86,7 @@ module ManageIQ
             payload = decode_body(message.headers, message.value)
             sender, event_type = parse_event_headers(message.headers)
             logger.info("Event received: topic(#{topic}), event(#{payload_log(payload)}), sender(#{sender}), type(#{event_type})")
-            yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, payload, message)
+            yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, payload, message, self)
             logger.info("Event processed")
           rescue StandardError => e
             logger.error("Event processing error: #{e.message}")

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -28,7 +28,7 @@ module ManageIQ
             begin
               messages = batch.messages.collect do |message|
                 sender, message_type, _class_name, payload = process_queue_message(topic, message)
-                ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, payload, message)
+                ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, payload, message, self)
               end
 
               yield messages

--- a/lib/manageiq/messaging/received_message.rb
+++ b/lib/manageiq/messaging/received_message.rb
@@ -1,10 +1,14 @@
 module ManageIQ
   module Messaging
     class ReceivedMessage
-      attr_accessor :sender, :message, :payload, :ack_ref
+      attr_accessor :sender, :message, :payload, :ack_ref, :client
 
-      def initialize(sender, message, payload, ack_ref)
-        @sender, @message, @payload, @ack_ref = sender, message, payload, ack_ref
+      def initialize(sender, message, payload, ack_ref, client)
+        @sender, @message, @payload, @ack_ref, @client = sender, message, payload, ack_ref, client
+      end
+
+      def ack
+        client.ack(ack_ref)
       end
     end
   end

--- a/lib/manageiq/messaging/stomp/queue.rb
+++ b/lib/manageiq/messaging/stomp/queue.rb
@@ -35,7 +35,7 @@ module ManageIQ
               message_body = decode_body(msg.headers, msg.body)
               logger.info("Message received: queue(#{queue_name}), msg(#{payload_log(message_body)}), headers(#{msg.headers})")
 
-              result = yield [ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, message_body, msg)]
+              result = yield [ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, message_body, msg, self)]
               logger.info("Message processed")
 
               correlation_ref = msg.headers['correlation_id']

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -23,7 +23,7 @@ module ManageIQ
               event_type = event.headers['event_type']
               event_body = decode_body(event.headers, event.body)
               logger.info("Event received: queue(#{queue_name}), event(#{event_body}), headers(#{event.headers})")
-              yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, event_body, event)
+              yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, event_body, event, self)
               logger.info("Event processed")
             rescue => e
               logger.error("Event processing error: #{e.message}")

--- a/spec/manageiq/messaging/stomp/client_spec.rb
+++ b/spec/manageiq/messaging/stomp/client_spec.rb
@@ -54,7 +54,16 @@ describe ManageIQ::Messaging::Stomp::Client do
           hash_including(:"subscription-type" => 'MULTICAST', :ack => 'client', :"durable-subscription-name" => 'ref')).and_yield(raw_message)
         expect(subject).not_to receive(:ack)
 
-        subject.subscribe_topic(:service => 's', :persist_ref => 'ref', :auto_ack => auto_ack) { |message| nil}
+        subject.subscribe_topic(:service => 's', :persist_ref => 'ref', :auto_ack => auto_ack) { |message| nil }
+      end
+
+      it 'acks the message on demand' do
+        expect(raw_client).to receive(:subscribe).with(
+          'topic/s',
+          hash_including(:"subscription-type" => 'MULTICAST', :ack => 'client', :"durable-subscription-name" => 'ref')).and_yield(raw_message)
+        expect(subject).to receive(:ack).with(raw_message)
+
+        subject.subscribe_topic(:service => 's', :persist_ref => 'ref', :auto_ack => auto_ack) { |message| message.ack }
       end
     end
 


### PR DESCRIPTION
Instead of requiring the caller call client.ack(msg.ack_ref) simply
allow calling ack on the message directly.

E.g.:
client.ack(msg.ack_ref)
becomes
msg.ack