### PR TITLE
Add an optional session_timeout option for kafka

### DIFF
--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -29,6 +29,7 @@ module ManageIQ
       #
       # Kafka specific +subscribe_messages+ options:
       # * :max_bytes (Max batch size to read, default is 10Mb)
+      # * :session_timeout (Max time in seconds allowed to process a message, default is 30)
       #
       # Without +:persist_ref+ every topic subscriber receives a copy of each message
       # only when they are active. If multiple topic subscribers join with the same

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -26,6 +26,7 @@ module ManageIQ
       #
       # Kafka specific +subscribe_topic+ options:
       # * :persist_ref (Used as Kafka group_id)
+      # * :session_timeout (Max time in seconds allowed to process a message, default is 30)
       #
       # Kafka specific +subscribe_messages+ options:
       # * :max_bytes (Max batch size to read, default is 10Mb)

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -21,11 +21,15 @@ module ManageIQ
           @topic_consumer ||= kafka_client.consumer(:group_id => persist_ref)
         end
 
-        def queue_consumer(topic)
+        def queue_consumer(topic, session_timeout = nil)
           # all queue consumers join the same group so that each message can be processed by one and only one consumer
           @queue_consumer.try(:stop) unless @queue_topic == topic
           @queue_topic = topic
-          @queue_consumer ||= kafka_client.consumer(:group_id => GROUP_FOR_QUEUE_MESSAGES + topic)
+
+          consumer_opts = {:group_id => GROUP_FOR_QUEUE_MESSAGES + topic}
+          consumer_opts[:session_timeout] = session_timeout if session_timeout.present?
+
+          @queue_consumer ||= kafka_client.consumer(consumer_opts)
         end
 
         trap("TERM") do

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -13,12 +13,16 @@ module ManageIQ
           @producer ||= kafka_client.producer
         end
 
-        def topic_consumer(persist_ref)
+        def topic_consumer(persist_ref, session_timeout = nil)
           # persist_ref enables consumer to receive messages sent when consumer is temporarily offline
           # it also enables consumers to do load balancing when multiple consumers join the with the same ref.
           @topic_consumer.try(:stop) unless @persist_ref == persist_ref
           @persist_ref = persist_ref
-          @topic_consumer ||= kafka_client.consumer(:group_id => persist_ref)
+
+          consumer_opts = {:group_id => persist_ref}
+          consumer_opts[:session_timeout] = session_timeout if session_timeout.present?
+
+          @topic_consumer ||= kafka_client.consumer(consumer_opts)
         end
 
         def queue_consumer(topic, session_timeout = nil)

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -16,12 +16,13 @@ module ManageIQ
 
         def subscribe_messages_impl(options)
           topic = address(options)
+          session_timeout = options[:session_timeout] if options.key?(:session_timeout)
 
           batch_options = {}
           batch_options[:automatically_mark_as_processed] = auto_ack?(options)
           batch_options[:max_bytes] = options[:max_bytes] if options.key?(:max_bytes)
 
-          consumer = queue_consumer(topic)
+          consumer = queue_consumer(topic, session_timeout)
           consumer.subscribe(topic)
           consumer.each_batch(batch_options) do |batch|
             logger.info("Batch message received: queue(#{topic})")

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -16,7 +16,7 @@ module ManageIQ
 
         def subscribe_messages_impl(options)
           topic = address(options)
-          session_timeout = options[:session_timeout] if options.key?(:session_timeout)
+          session_timeout = options[:session_timeout]
 
           batch_options = {}
           batch_options[:automatically_mark_as_processed] = auto_ack?(options)

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -10,10 +10,11 @@ module ManageIQ
 
         def subscribe_topic_impl(options, &block)
           topic = address(options)
-          persist_ref = options[:persist_ref]
+          persist_ref     = options[:persist_ref]
+          session_timeout = options[:session_timeout] if options.key?(:session_timeout)
 
           if persist_ref
-            consumer = topic_consumer(persist_ref)
+            consumer = topic_consumer(persist_ref, session_timeout)
             consumer.subscribe(topic, :start_from_beginning => false)
             consumer.each_message(:automatically_mark_as_processed => auto_ack?(options)) do |message|
               process_topic_message(topic, message, &block)

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -11,7 +11,7 @@ module ManageIQ
         def subscribe_topic_impl(options, &block)
           topic = address(options)
           persist_ref     = options[:persist_ref]
-          session_timeout = options[:session_timeout] if options.key?(:session_timeout)
+          session_timeout = options[:session_timeout]
 
           if persist_ref
             consumer = topic_consumer(persist_ref, session_timeout)


### PR DESCRIPTION
Add an option to control the kafka session_timeout which defaults to 30
seconds and has a maximum by default of 5 minutes.  This maximum can be
updated by changing group.max.session.timeout.ms on the broker.