### PR TITLE
Release v0.1.4

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,3 +7,7 @@
 
 = 0.1.2 - 11-Dec-2018
 * Allow to set max_bytes to each_batch when subscribe to a Kafka topic.
+
+= 0.1.4 - 3-Apr-2019
+* Add an #ack method to a ReceivedMessage to simplify manual acknowledgements
+* Allow caller to provide a session_timeout to kafka consumers, default of 30sec

--- a/lib/manageiq/messaging/version.rb
+++ b/lib/manageiq/messaging/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
   module Messaging
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end


### PR DESCRIPTION
Changes:
* Add an #ack method to a ReceivedMessage to simplify manual acknowledgements
* Allow caller to provide a session_timeout to kafka consumers, default
of 30sec