### PR TITLE
Allow extra headers to be passed with the message

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ If you want you can add in your own headers to the send message
   )
 
   client.subscribe_topic(:service => 'provider_events', :persist_ref => 'automate_1') do |msg|
-    puts "Received event #{msg.message} with request-id: #{msg.headers[:request_id]}"
+    puts "Received event #{msg.message} with request-id: #{msg.headers['request_id']}"
   end
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,24 @@ This is the one-to-many publish/subscribe pattern. Multiple subscribers can subs
 
 By default, events are delivered to live subscribers only. Some messaging systems support persistence with options.
 
+### Add your own headers to a message (Queue or Topic)
+
+If you want you can add in your own headers to the send message
+
+```
+  client.publish_topic(
+    :service => 'provider_events',
+    :event   => 'powered_on',
+    :headers => {:request_id => "12345"},
+    :payload => {:ems_ref => 'uid987'}
+
+  )
+
+  client.subscribe_topic(:service => 'provider_events', :persist_ref => 'automate_1') do |msg|
+    puts "Received event #{msg.message} with request-id: #{msg.headers[:request_id]}"
+  end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -58,6 +58,7 @@ module ManageIQ
       # * :message    (e.g. method name or message type)
       # * :payload    (message body, a string or an user object that can be serialized)
       # * :sender     (optional, identify the sender)
+      # * :headers    (optional, additional headers to add to the message)
       # Other options are underlying messaging system specific.
       #
       # Optionally a call back block can be provided to wait on the consumer to send
@@ -164,6 +165,7 @@ module ManageIQ
       # * :event   (event name)
       # * :payload (message body, a string or an user object that can be serialized)
       # * :sender  (optional, identify the sender)
+      # * :headers (optional, additional headers to add to the message)
       # Other options are underlying messaging system specific.
       #
       def publish_topic(options)

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -87,7 +87,7 @@ module ManageIQ
           payload = decode_body(message.headers, message.value)
           sender, message_type, class_name = parse_message_headers(message.headers)
           logger.info("Message received: queue(#{queue}), message(#{payload_log(payload)}), sender(#{sender}), type(#{message_type})")
-          [sender, message_type, class_name, payload]
+          [sender, message_type, class_name, payload, message.headers]
         end
 
         def process_topic_message(topic, message)
@@ -95,7 +95,7 @@ module ManageIQ
             payload = decode_body(message.headers, message.value)
             sender, event_type = parse_event_headers(message.headers)
             logger.info("Event received: topic(#{topic}), event(#{payload_log(payload)}), sender(#{sender}), type(#{event_type})")
-            yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, payload, message, self)
+            yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, payload, message.headers, message, self)
             logger.info("Event processed")
           rescue StandardError => e
             logger.error("Event processing error: #{e.message}")

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -65,8 +65,9 @@ module ManageIQ
         end
 
         def for_publish(options)
-          kafka_opts = {:topic => address(options), :headers => {}}
-          kafka_opts[:partition_key] = options[:group_name] if options[:group_name]
+          kafka_opts = {:topic => address(options)}
+          kafka_opts[:partition_key]    = options[:group_name] if options[:group_name]
+          kafka_opts[:headers]          = options[:headers] || {}
           kafka_opts[:headers][:sender] = options[:sender] if options[:sender]
 
           body = options[:payload] || ''

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -29,7 +29,7 @@ module ManageIQ
             begin
               messages = batch.messages.collect do |message|
                 sender, message_type, _class_name, payload = process_queue_message(topic, message)
-                ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, payload, message, self)
+                ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, payload, headers, message, self)
               end
 
               yield messages

--- a/lib/manageiq/messaging/received_message.rb
+++ b/lib/manageiq/messaging/received_message.rb
@@ -1,10 +1,10 @@
 module ManageIQ
   module Messaging
     class ReceivedMessage
-      attr_accessor :sender, :message, :payload, :ack_ref, :client
+      attr_accessor :sender, :message, :payload, :headers, :ack_ref, :client
 
-      def initialize(sender, message, payload, ack_ref, client)
-        @sender, @message, @payload, @ack_ref, @client = sender, message, payload, ack_ref, client
+      def initialize(sender, message, payload, headers, ack_ref, client)
+        @sender, @message, @payload, @headers, @ack_ref, @client = sender, message, payload, headers, ack_ref, client
       end
 
       def ack

--- a/lib/manageiq/messaging/stomp/common.rb
+++ b/lib/manageiq/messaging/stomp/common.rb
@@ -17,6 +17,8 @@ module ManageIQ
           address = "queue/#{options[:service]}.#{affinity}"
 
           headers = {:"destination-type" => 'ANYCAST', :persistent => true}
+          headers.merge!(options[:headers]) if options.key?(:headers)
+
           headers[:expires]            = options[:expires_on].to_i * 1000 if options[:expires_on]
           headers[:AMQ_SCHEDULED_TIME] = options[:deliver_on].to_i * 1000 if options[:deliver_on]
           headers[:priority]           = options[:priority] if options[:priority]
@@ -38,6 +40,8 @@ module ManageIQ
           address = "topic/#{options[:service]}"
 
           headers = {:"destination-type" => 'MULTICAST', :persistent => true}
+          headers.merge!(options[:headers]) if options.key?(:headers)
+
           headers[:expires]            = options[:expires_on].to_i * 1000 if options[:expires_on]
           headers[:AMQ_SCHEDULED_TIME] = options[:deliver_on].to_i * 1000 if options[:deliver_on]
           headers[:priority]           = options[:priority] if options[:priority]

--- a/lib/manageiq/messaging/stomp/common.rb
+++ b/lib/manageiq/messaging/stomp/common.rb
@@ -17,7 +17,7 @@ module ManageIQ
           address = "queue/#{options[:service]}.#{affinity}"
 
           headers = {:"destination-type" => 'ANYCAST', :persistent => true}
-          headers.merge!(options[:headers]) if options.key?(:headers)
+          headers.merge!(options[:headers].except(*internal_header_keys)) if options.key?(:headers)
 
           headers[:expires]            = options[:expires_on].to_i * 1000 if options[:expires_on]
           headers[:AMQ_SCHEDULED_TIME] = options[:deliver_on].to_i * 1000 if options[:deliver_on]
@@ -40,7 +40,7 @@ module ManageIQ
           address = "topic/#{options[:service]}"
 
           headers = {:"destination-type" => 'MULTICAST', :persistent => true}
-          headers.merge!(options[:headers]) if options.key?(:headers)
+          headers.merge!(options[:headers].except(*internal_header_keys)) if options.key?(:headers)
 
           headers[:expires]            = options[:expires_on].to_i * 1000 if options[:expires_on]
           headers[:AMQ_SCHEDULED_TIME] = options[:deliver_on].to_i * 1000 if options[:deliver_on]
@@ -65,6 +65,10 @@ module ManageIQ
           }
           address, response_headers = queue_for_publish(response_options)
           raw_publish(address, result || '', response_headers.merge(:correlation_id => correlation_ref))
+        end
+
+        def internal_header_keys
+          [:"destination-type", :persistent, :expires, :AMQ_SCHEDULED_TIME, :priority, :_AMQ_GROUP_ID]
         end
 
         def receive_response(service, correlation_ref)

--- a/lib/manageiq/messaging/stomp/queue.rb
+++ b/lib/manageiq/messaging/stomp/queue.rb
@@ -33,9 +33,15 @@ module ManageIQ
               sender = msg.headers['sender']
               message_type = msg.headers['message_type']
               message_body = decode_body(msg.headers, msg.body)
+              client_headers = msg.headers.except(*internal_header_keys)
+
               logger.info("Message received: queue(#{queue_name}), msg(#{payload_log(message_body)}), headers(#{msg.headers})")
 
-              result = yield [ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, message_body, msg.headers, msg, self)]
+              messages = [
+                ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, message_body, client_headers, msg, self)
+              ]
+
+              result = yield messages
               logger.info("Message processed")
 
               correlation_ref = msg.headers['correlation_id']

--- a/lib/manageiq/messaging/stomp/queue.rb
+++ b/lib/manageiq/messaging/stomp/queue.rb
@@ -35,7 +35,7 @@ module ManageIQ
               message_body = decode_body(msg.headers, msg.body)
               logger.info("Message received: queue(#{queue_name}), msg(#{payload_log(message_body)}), headers(#{msg.headers})")
 
-              result = yield [ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, message_body, msg, self)]
+              result = yield [ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, message_body, msg.headers, msg, self)]
               logger.info("Message processed")
 
               correlation_ref = msg.headers['correlation_id']

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -23,7 +23,7 @@ module ManageIQ
               event_type = event.headers['event_type']
               event_body = decode_body(event.headers, event.body)
               logger.info("Event received: queue(#{queue_name}), event(#{event_body}), headers(#{event.headers})")
-              yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, event_body, event, self)
+              yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, event_body, event.headers, event, self)
               logger.info("Event processed")
             rescue => e
               logger.error("Event processing error: #{e.message}")

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -21,9 +21,11 @@ module ManageIQ
 
               sender = event.headers['sender']
               event_type = event.headers['event_type']
+              client_headers = event.headers.except(*internal_header_keys)
+
               event_body = decode_body(event.headers, event.body)
               logger.info("Event received: queue(#{queue_name}), event(#{event_body}), headers(#{event.headers})")
-              yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, event_body, event.headers, event, self)
+              yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, event_body, client_headers, event, self)
               logger.info("Event processed")
             rescue => e
               logger.error("Event processing error: #{e.message}")

--- a/manageiq-messaging.gemspec
+++ b/manageiq-messaging.gemspec
@@ -24,10 +24,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ruby-kafka', '~> 0.7.0'
   spec.add_dependency 'stomp', '~> 1.4.4'
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "simplecov"
 end

--- a/spec/manageiq/messaging/kafka/client_spec.rb
+++ b/spec/manageiq/messaging/kafka/client_spec.rb
@@ -40,11 +40,19 @@ describe ManageIQ::Messaging::Kafka::Client do
         hash_including(
           :topic         => 's',
           :partition_key => 'a',
-          :headers       => hash_including(:event_type => 'e', :encoding => 'yaml')
+          :headers       => hash_including(
+            :event_type => 'e', :encoding => 'yaml', :identity => "1234"
+          )
         )
       )
 
-      subject.publish_topic(:service => 's', :event => 'e', :group_name => 'a', :payload => [1, 2, 3])
+      subject.publish_topic(
+        :service => 's',
+        :event => 'e',
+        :group_name => 'a',
+        :headers => {:identity => "1234"},
+        :payload => [1, 2, 3]
+      )
     end
   end
 
@@ -99,13 +107,16 @@ describe ManageIQ::Messaging::Kafka::Client do
       expect(producer).to receive(:deliver_messages)
       expect(producer).to receive(:produce).with(
         'p',
-        hash_including(:topic => 's.uid', :headers => {:message_type => 'm'})
+        hash_including(
+          :topic => 's.uid', :headers => {:message_type => 'm', :identity => "1234"}
+        )
       )
 
       subject.publish_message(
         :service    => 's',
         :message    => 'm',
         :affinity   => 'uid',
+        :headers    => {:identity => "1234"},
         :payload    => 'p')
     end
 


### PR DESCRIPTION
There are some cases where extra headers should be added to the message
and there currently is no interface to be able to do that.

This adds the ability to pass other arbitrary headers in to
publish_topic/publish_message.