### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,6 +34,7 @@ engines:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: 'rubocop-0-69'
 prepare:
   fetch:
   - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # ManageIQ Messaging Client
 
 [![Gem Version](https://badge.fury.io/rb/manageiq-messaging.svg)](http://badge.fury.io/rb/manageiq-messaging)
-[![Build Status](https://travis-ci.org/ManageIQ/manageiq-messaging.svg)](https://travis-ci.org/ManageIQ/manageiq-messaging)
+[![Build Status](https://travis-ci.com/ManageIQ/manageiq-messaging.svg)](https://travis-ci.com/ManageIQ/manageiq-messaging)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/manageiq-messaging.svg)](https://codeclimate.com/github/ManageIQ/manageiq-messaging)
 [![Test Coverage](https://codeclimate.com/github/ManageIQ/manageiq-messaging/badges/coverage.svg)](https://codeclimate.com/github/ManageIQ/manageiq-messaging/coverage)
-[![Dependency Status](https://gemnasium.com/ManageIQ/manageiq-messaging.svg)](https://gemnasium.com/ManageIQ/manageiq-messaging)
 [![Security](https://hakiri.io/github/ManageIQ/manageiq-messaging/master.svg)](https://hakiri.io/github/ManageIQ/manageiq-messaging/master)
 
 Client library for ManageIQ components to exchange messages through its internal message bus.


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.
Also, changed travis-ci.org to travis-ci.com
Also, added rubocop channel to .codeclimate.yml