### PR TITLE
Catch decoding parsing error

### DIFF
--- a/lib/manageiq/messaging/common.rb
+++ b/lib/manageiq/messaging/common.rb
@@ -26,6 +26,10 @@ module ManageIQ
         else
           raw_body
         end
+      rescue => e # JSON or YAML parsing error
+        logger.error("Error decoding message body: #{e.message}")
+        logger.error(e.backtrace.join("\n"))
+        raw_body
       end
 
       def payload_log(payload)

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -36,6 +36,7 @@ module ManageIQ
             rescue StandardError => e
               logger.error("Event processing error: #{e.message}")
               logger.error(e.backtrace.join("\n"))
+              raise
             end
             logger.info("Batch message processed")
           end

--- a/lib/manageiq/messaging/stomp/queue.rb
+++ b/lib/manageiq/messaging/stomp/queue.rb
@@ -52,6 +52,7 @@ module ManageIQ
             rescue => e
               logger.error("Message processing error: #{e.message}")
               logger.error(e.backtrace.join("\n"))
+              raise
             end
           end
         end

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -30,6 +30,7 @@ module ManageIQ
             rescue => e
               logger.error("Event processing error: #{e.message}")
               logger.error(e.backtrace.join("\n"))
+              raise
             end
           end
         end


### PR DESCRIPTION
An efford of improving error handling for subscribing. When a message is received we first try to decode the body and then yield to caller to process the message. It is the gem's responsibility not to raise an error or to crash the listener thread. It is the caller's responsibility not to raise an error during the process. If it does happen, the gem should not consume the error. PR #44 already re-raise the error for Kafka events. We now apply the same logic to all other subscribing types.
