### PR TITLE
Add protocol Rdkafka, a Kafka client relying on libkafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or install it yourself as:
 
 ### Initialize a client
 
-It is not recommended to directly create an actual client through `new` operation. Follow the example by specifying a protocol. This allows to easily switch the underlying messaging system from one type to another. Currently `:Stomp` and `:Kafka` are implemented.
+It is not recommended to directly create an actual client through `new` operation. Follow the example by specifying a protocol. This allows to easily switch the underlying messaging system from one type to another. Currently `:Stomp`, `:Kafka`, and `:Rdkafka` are implemented. `:Rdkafka` is the same as Kafka, but relies on librdkafka C++ library.
 
 ```
   ManageIQ::Messaging.logger = Logger.new(STDOUT)

--- a/lib/manageiq/messaging.rb
+++ b/lib/manageiq/messaging.rb
@@ -8,6 +8,7 @@ module ManageIQ
   module Messaging
     autoload :Stomp, 'manageiq/messaging/stomp'
     autoload :Kafka, 'manageiq/messaging/kafka'
+    autoload :Rdkafka, 'manageiq/messaging/rdkafka'
 
     class << self
       attr_writer :logger

--- a/lib/manageiq/messaging/rdkafka.rb
+++ b/lib/manageiq/messaging/rdkafka.rb
@@ -1,0 +1,7 @@
+module ManageIQ
+  module Messaging
+    module Rdkafka
+      autoload :Client, 'manageiq/messaging/rdkafka/client'
+    end
+  end
+end

--- a/lib/manageiq/messaging/rdkafka/background_job.rb
+++ b/lib/manageiq/messaging/rdkafka/background_job.rb
@@ -1,0 +1,13 @@
+module ManageIQ
+  module Messaging
+    module Rdkafka
+      module BackgroundJob
+        private
+
+        def subscribe_background_job_impl(_options)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/rdkafka/common.rb
+++ b/lib/manageiq/messaging/rdkafka/common.rb
@@ -1,0 +1,120 @@
+module ManageIQ
+  module Messaging
+    module Rdkafka
+      module Common
+        require 'manageiq/messaging/common'
+        include ManageIQ::Messaging::Common
+
+        private
+
+        def producer
+          @producer ||= kafka_client.producer
+        end
+
+        def consumer(beginning, options)
+          @consumer&.close
+          kafka_client[:"group.id"] = options[:persist_ref]
+          kafka_client[:"auto.offset.reset"] = beginning ? 'smallest' : 'largest'
+          kafka_client[:"enable.auto.commit"] = !!auto_ack?(options)
+          kafka_client[:"session.timeout.ms"] = options[:session_timeout] * 1000 if options[:session_timeout].present?
+          kafka_client[:"group.instance.id"] = options[:group_instance_id] if options[:group_instance_id].present?
+          @consumer = kafka_client.consumer
+        end
+
+        def raw_publish(wait, body, options)
+          options[:payload] = encode_body(options[:headers], body)
+          producer.produce(options).tap do |handle|
+            handle.wait if wait
+            logger.info("Published to topic(#{options[:topic]}), msg(#{payload_log(body.inspect)})")
+          end
+        end
+
+        def queue_for_publish(options)
+          body, kafka_opts = for_publish(options)
+          kafka_opts[:headers][:message_type] = options[:message] if options[:message]
+          kafka_opts[:headers][:class_name] = options[:class_name] if options[:class_name]
+          kafka_opts[:headers].merge!(options[:headers].except(*message_header_keys)) if options.key?(:headers)
+
+          [body, kafka_opts]
+        end
+
+        def topic_for_publish(options)
+          body, kafka_opts = for_publish(options)
+          kafka_opts[:headers][:event_type] = options[:event] if options[:event]
+          kafka_opts[:headers].merge!(options[:headers].except(*event_header_keys)) if options.key?(:headers)
+
+          [body, kafka_opts]
+        end
+
+        def for_publish(options)
+          kafka_opts = {:topic => address(options)}
+          kafka_opts[:partition_key] = options[:group_name] if options[:group_name]
+          kafka_opts[:headers] = {}
+          kafka_opts[:headers][:sender] = options[:sender] if options[:sender]
+
+          body = options[:payload] || ''
+
+          [body, kafka_opts]
+        end
+
+        def address(options)
+          if options[:affinity]
+            "#{options[:service]}.#{options[:affinity]}"
+          else
+            options[:service]
+          end
+        end
+
+        def process_queue_message(queue_consumer, queue, message)
+          begin
+            payload = decode_body(message.headers, message.payload)
+            sender, message_type, class_name = parse_message_headers(message.headers)
+            client_headers = message.headers.except(*message_header_keys).with_indifferent_access
+
+            logger.info("Message received: queue(#{queue}), message(#{payload_log(payload)}), sender(#{sender}), type(#{message_type})")
+            yield [ManageIQ::Messaging::ReceivedMessage.new(sender, message_type, payload, client_headers, queue_consumer, self)]
+            logger.info("Messsage processed")
+          rescue StandardError => e
+            logger.error("Message processing error: #{e.message}")
+            logger.error(e.backtrace.join("\n"))
+            raise
+          end
+        end
+
+        def process_topic_message(topic_consumer, topic, message)
+          begin
+            payload = decode_body(message.headers, message.payload)
+            sender, event_type = parse_event_headers(message.headers)
+            client_headers = message.headers.except(*event_header_keys).with_indifferent_access
+
+            logger.info("Event received: topic(#{topic}), event(#{payload_log(payload)}), sender(#{sender}), type(#{event_type})")
+            yield ManageIQ::Messaging::ReceivedMessage.new(sender, event_type, payload, client_headers, topic_consumer, self)
+            logger.info("Event processed")
+          rescue StandardError => e
+            logger.error("Event processing error: #{e.message}")
+            logger.error(e.backtrace.join("\n"))
+            raise
+          end
+        end
+
+        def message_header_keys
+          [:sender, :message_type, :class_name]
+        end
+
+        def parse_message_headers(headers)
+          return [nil, nil, nil] unless headers.kind_of?(Hash)
+          headers.values_at(*message_header_keys)
+        end
+
+        def event_header_keys
+          [:sender, :event_type]
+        end
+
+        def parse_event_headers(headers)
+          return [nil, nil] unless headers.kind_of?(Hash)
+          headers.values_at(*event_header_keys)
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/rdkafka/queue.rb
+++ b/lib/manageiq/messaging/rdkafka/queue.rb
@@ -1,0 +1,32 @@
+module ManageIQ
+  module Messaging
+    module Rdkafka
+      module Queue
+        GROUP_FOR_QUEUE_MESSAGES = 'manageiq_messaging_queue_group_'.freeze
+
+        private
+
+        def publish_message_impl(options)
+          raise ArgumentError, "Kafka messaging implementation does not take a block" if block_given?
+          raw_publish(true, *queue_for_publish(options))
+        end
+
+        def publish_messages_impl(messages)
+          handles = messages.collect { |msg_options| raw_publish(false, *queue_for_publish(msg_options)) }
+          handles.each(&:wait)
+        end
+
+        def subscribe_messages_impl(options, &block)
+          topic = address(options)
+          options[:persist_ref] = GROUP_FOR_QUEUE_MESSAGES + topic
+
+          queue_consumer = consumer(true, options)
+          queue_consumer.subscribe(topic)
+          queue_consumer.each do |message|
+              process_queue_message(queue_consumer, topic, message, &block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/messaging/rdkafka/topic.rb
+++ b/lib/manageiq/messaging/rdkafka/topic.rb
@@ -1,0 +1,26 @@
+module ManageIQ
+  module Messaging
+    module Rdkafka
+      module Topic
+        GROUP_FOR_ADHOC_LISTENERS = 'manageiq_messaging_topic_group_'.freeze
+
+        private
+
+        def publish_topic_impl(options)
+          raw_publish(true, *topic_for_publish(options))
+        end
+
+        def subscribe_topic_impl(options, &block)
+          topic = address(options)
+
+          options[:persist_ref] = "#{GROUP_FOR_ADHOC_LISTENERS}_#{Time.now.to_i}" unless options[:persist_ref]
+          topic_consumer = consumer(false, options)
+          topic_consumer.subscribe(topic)
+          topic_consumer.each do |message|
+              process_topic_message(topic_consumer, topic, message, &block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/manageiq-messaging.gemspec
+++ b/manageiq-messaging.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '~> 5.2.4.3'
   spec.add_dependency 'ruby-kafka', '~> 1.0'
+  spec.add_dependency 'rdkafka', '~> 0.8'
   spec.add_dependency 'stomp', '~> 1.4.4'
 
   spec.add_development_dependency "bundler"

--- a/spec/manageiq/messaging/rdkafka/client_spec.rb
+++ b/spec/manageiq/messaging/rdkafka/client_spec.rb
@@ -1,0 +1,174 @@
+require "spec_helper"
+
+describe ManageIQ::Messaging::Rdkafka::Client do
+  let(:producer)   { double(:producer) }
+  let(:consumer)   { double(:consumer) }
+  let(:raw_client) do
+    {}.tap do |h|
+      allow(h).to receive(:producer).and_return(producer)
+      allow(h).to receive(:consumer).and_return(consumer)
+    end
+  end
+
+  subject do
+    allow(::Rdkafka::Config).to receive(:new).and_return(raw_client)
+    described_class.new(:host => 'localhost', :port => 1234)
+  end
+
+  describe '#initialize' do
+    it 'creates a client connects to a single host' do
+      expect(::Rdkafka::Config).to receive(:new).with(:"bootstrap.servers"=>"localhost:1234", :"client.id"=>"my-ref")
+
+      described_class.new(
+        :protocol   => 'Rdkafka',
+        :host       => 'localhost',
+        :port       => 1234,
+        :client_ref => 'my-ref'
+      )
+    end
+
+    it 'creates a client connects to a cluster' do
+      expect(::Rdkafka::Config).to receive(:new).with({:"bootstrap.servers"=>"host1:1234,host2:1234", :"client.id"=>"my-ref"})
+
+      described_class.new(
+        :protocol   => 'Rdkafka',
+        :hosts      => %w(host1 host2),
+        :port       => 1234,
+        :client_ref => 'my-ref'
+      )
+    end
+  end
+
+  describe '#publish_topic' do
+    it 'sends the message to the topic' do
+      expect(producer).to receive(:produce).with(
+        hash_including(
+          :payload       => "---\n- 1\n- 2\n- 3\n",
+          :topic         => 's',
+          :partition_key => 'a',
+          :headers       => hash_including(
+            :event_type => 'e', :encoding => 'yaml', :identity => "1234"
+          )
+        )
+      ).and_return(double(:handle, :wait => nil))
+
+      subject.publish_topic(
+        :service => 's',
+        :event => 'e',
+        :group_name => 'a',
+        :headers => {:identity => "1234"},
+        :payload => [1, 2, 3]
+      )
+    end
+  end
+
+  describe '#subscribe_topic' do
+    let(:raw_message) { double(:raw_message, :headers => {'sender' => 'x', 'event_type' => 'y'}, :payload => 'v') }
+
+    before do
+      allow(consumer).to receive(:subscribe)
+      allow(consumer).to receive(:each).and_yield(raw_message)
+    end
+
+    context 'no auto_ack' do
+      let(:auto_ack) { false }
+
+      it 'listens to the topic with persist_ref' do
+        subject.subscribe_topic(:service => 's', :persist_ref => 'pid', :auto_ack => auto_ack) { |message| nil }
+        expect(raw_client).to include(:"group.id" => 'pid', :"auto.offset.reset" => 'largest', :"enable.auto.commit" => false)
+      end
+
+      it 'listens to the topic without persist_ref' do
+        subject.subscribe_topic(:service => 's') { |message| nil }
+        expect(raw_client).to include(:"group.id" => /manageiq_messaging_topic_group_/, :"auto.offset.reset" => 'largest', :"enable.auto.commit" => true)
+      end
+
+      it 'acks the message on demand' do
+        expect(consumer).to receive(:commit)
+        subject.subscribe_topic(:service => 's', :persist_ref => 'pid', :auto_ack => auto_ack) { |message| message.ack }
+      end
+    end
+
+    context 'auto_ack' do
+      let(:auto_ack) { true }
+
+      it 'acks the message automatically' do
+        expect(consumer).not_to receive(:commit)
+        subject.subscribe_topic(:service => 's', :persist_ref => 'pid', :auto_ack => auto_ack) { |message| nil }
+      end
+    end
+  end
+
+  describe '#publish_message' do
+    it 'sends a message with affinity to the queue' do
+      expect(producer).to receive(:produce).with(
+        hash_including(
+          :payload => 'p', :topic => 's.uid', :headers => {:message_type => 'm', :identity => "1234"}
+        )
+      ).and_return(double(:handle, :wait => nil))
+
+      subject.publish_message(
+        :service    => 's',
+        :message    => 'm',
+        :affinity   => 'uid',
+        :headers    => {:identity => "1234"},
+        :payload    => 'p')
+    end
+
+    it 'sends a message without affinity to the queue' do
+      expect(producer).to receive(:produce).with(
+        hash_including(:payload => 'p', :topic => 's', :headers => hash_including(:message_type => 'm', :sender => 'me'))
+      ).and_return(double(:handle, :wait => nil))
+
+      subject.publish_message(:service => 's', :message => 'm', :payload => 'p', :sender => 'me')
+    end
+  end
+
+  describe '#publish_message with json encoder' do
+    subject do
+      allow(::Rdkafka::Config).to receive(:new).and_return(raw_client)
+      described_class.new(:host => 'localhost', :port => 1234, :encoding => "json")
+    end
+
+    it 'sends alternative encoding to the queue' do
+      expect(producer).to receive(:produce).with(
+        hash_including(
+          :payload => "{\"instance_id\":1,\"args\":[\"arg1\",2]}",
+          :topic   => 's.uid',
+          :headers => hash_including(:message_type => 'my_method', :class_name => 'MyClass', :encoding => 'json')
+        )
+      ).and_return(double(:handle, :wait => nil))
+
+      subject.publish_message(
+        :service    => 's',
+        :class_name => 'MyClass',
+        :message    => 'my_method',
+        :affinity   => 'uid',
+        :payload    => { :instance_id => 1, :args => ['arg1', 2] })
+    end
+  end
+
+  describe '#subscribe_messages' do
+    let(:auto_ack) { false }
+ 
+    before do
+      allow(consumer).to receive(:subscribe)
+      allow(consumer).to receive(:each)
+    end
+
+    it 'listens to the queue with built-in group_id' do
+      subject.subscribe_messages(:service => 's', :affinity => 'uid', :auto_ack => auto_ack) { |messages| nil }
+      expect(raw_client).to include(:"group.id" => described_class::GROUP_FOR_QUEUE_MESSAGES + 's.uid', :"auto.offset.reset" => 'smallest', :"enable.auto.commit" => auto_ack)
+    end
+  end
+
+  describe '#publish_messages' do
+    it 'sends to the queue one by one but delivers once' do
+      expect(producer).to receive(:produce).with(hash_including(:payload => 'p1', :topic => 's', :headers => {:message_type => 'm'})).and_return(double(:handle, :wait => nil))
+      expect(producer).to receive(:produce).with(hash_including(:payload => 'p2', :topic => 's', :headers => {:message_type => 'm'})).and_return(double(:handle, :wait => nil))
+      subject.publish_messages([
+        {:service => 's', :message => 'm', :payload => 'p1' },
+        {:service => 's', :message => 'm', :payload => 'p2' }])
+    end
+  end
+end


### PR DESCRIPTION
manageiq-messaging uses ruby-kafka gem as the kafka client, a pure ruby implementation.
This work adds an option to use rdkafka-ruby gem, a client that wraps around libkafka C++ library. Libkafka supports more Kafka new released features.

In order to use rdkafka, the protocal option should be set to `:Rdkafka`, for example
```
  ManageIQ::Messaging::Client.open(
    :protocol   => :Rdkafka,
    :host       => 'localhost',
    :port       => 9092)
```
@Fryguy I was told that you prefer to keep both ruby-kafka and rdkafka. I feel we may completely switch to rdkafka by removing dependency on ruby-kafka. Zendesk who develops ruby-kafka swithed to use rdkafka in their racecar project: https://github.com/zendesk/racecar/pull/97

cc @lindgrenj6 @syncrou  