### PR TITLE
drop sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ rvm:
   - 2.6.5
 before_install: gem install bundler -v 1.13.0
 after_script: bundle exec codeclimate-test-reporter
-sudo: false
 cache: bundler


### PR DESCRIPTION
we no longer need sudo: false per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration (it was listed twice originally in this file)