### PR TITLE
Config kafka with all provided options

### DIFF
--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -84,7 +84,7 @@ module ManageIQ
 
           connection_opts = {:"bootstrap.servers" => hosts.join(',')}
           connection_opts[:"client.id"] = options[:client_ref] if options[:client_ref]
-          connection_opts = connection_opts.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref))
+          connection_opts.merge!(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref))
 
           ::Rdkafka::Config.logger = logger
           @kafka_client = ::Rdkafka::Config.new(connection_opts)

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -85,6 +85,11 @@ module ManageIQ
           connection_opts = {:"bootstrap.servers" => hosts.join(',')}
           connection_opts[:"client.id"] = options[:client_ref] if options[:client_ref]
 
+          options_copy = Hash[options]
+          [:port, :host, :hosts, :encoding, :protocol, :client_ref].each { |k| options_copy.delete(k) }
+
+          connection_opts = connection_opts.merge(options_copy)
+
           ::Rdkafka::Config.logger = logger
           @kafka_client = ::Rdkafka::Config.new(connection_opts)
         end

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -84,11 +84,7 @@ module ManageIQ
 
           connection_opts = {:"bootstrap.servers" => hosts.join(',')}
           connection_opts[:"client.id"] = options[:client_ref] if options[:client_ref]
-
-          options_copy = Hash[options]
-          [:port, :host, :hosts, :encoding, :protocol, :client_ref].each { |k| options_copy.delete(k) }
-
-          connection_opts = connection_opts.merge(options_copy)
+          connection_opts = connection_opts.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref))
 
           ::Rdkafka::Config.logger = logger
           @kafka_client = ::Rdkafka::Config.new(connection_opts)

--- a/spec/manageiq/messaging/kafka/client_spec.rb
+++ b/spec/manageiq/messaging/kafka/client_spec.rb
@@ -17,24 +17,26 @@ describe ManageIQ::Messaging::Kafka::Client do
 
   describe '#initialize' do
     it 'creates a client connects to a single host' do
-      expect(::Rdkafka::Config).to receive(:new).with(:"bootstrap.servers"=>"localhost:1234", :"client.id"=>"my-ref")
+      expect(::Rdkafka::Config).to receive(:new).with(:"bootstrap.servers" => "localhost:1234", :"client.id" => "my-ref", :"sasl.protocol" => "SASL_SSL")
 
       described_class.new(
-        :protocol   => 'Kafka',
-        :host       => 'localhost',
-        :port       => 1234,
-        :client_ref => 'my-ref'
+        :protocol        => 'Kafka',
+        :host            => 'localhost',
+        :port            => 1234,
+        :client_ref      => 'my-ref',
+        :"sasl.protocol" => "SASL_SSL"
       )
     end
 
     it 'creates a client connects to a cluster' do
-      expect(::Rdkafka::Config).to receive(:new).with({:"bootstrap.servers"=>"host1:1234,host2:1234", :"client.id"=>"my-ref"})
+      expect(::Rdkafka::Config).to receive(:new).with({:"bootstrap.servers" => "host1:1234,host2:1234", :"client.id" => "my-ref", :"sasl.protocol" => "SASL_SSL"})
 
       described_class.new(
-        :protocol   => 'Kafka',
-        :hosts      => %w(host1 host2),
-        :port       => 1234,
-        :client_ref => 'my-ref'
+        :protocol        => 'Kafka',
+        :hosts           => %w[host1 host2],
+        :port            => 1234,
+        :client_ref      => 'my-ref',
+        :"sasl.protocol" => "SASL_SSL"
       )
     end
   end


### PR DESCRIPTION
This is part of the solution for:
https://github.com/ManageIQ/manageiq-appliance-build/issues/456

Different security protocols will have different options. This PR will support this by passing
all provided options to `::Rdkafka::Config.new`