### PR TITLE
remove deprecated codeclimate test reporter gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,10 @@ rvm:
   - 2.5.7
   - 2.6.5
 before_install: gem install bundler -v 1.13.0
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 cache: bundler

--- a/manageiq-messaging.gemspec
+++ b/manageiq-messaging.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'stomp', '~> 1.4.4'
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779 got added last week

@miq-bot add_label dependencies, test 
@miq-bot assign @Fryguy 