### PR TITLE
Convert standard options to sasl parameters

### DIFF
--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -84,7 +84,10 @@ module ManageIQ
 
           connection_opts = {:"bootstrap.servers" => hosts.join(',')}
           connection_opts[:"client.id"] = options[:client_ref] if options[:client_ref]
-          connection_opts.merge!(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref))
+          connection_opts[:"sasl.username"] = options[:username] if options[:username]
+          connection_opts[:"sasl.password"] = options[:password] if options[:password]
+
+          connection_opts.merge!(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :username, :password))
 
           ::Rdkafka::Config.logger = logger
           @kafka_client = ::Rdkafka::Config.new(connection_opts)

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -76,21 +76,23 @@ module ManageIQ
         attr_reader :kafka_client
 
         def initialize(options)
-          hosts = Array(options[:hosts] || options[:host])
-          hosts.collect! { |host| "#{host}:#{options[:port]}" }
-
           @encoding = options[:encoding] || 'yaml'
           require "json" if @encoding == "json"
 
-          connection_opts = {:"bootstrap.servers" => hosts.join(',')}
-          connection_opts[:"client.id"] = options[:client_ref] if options[:client_ref]
-          connection_opts[:"sasl.username"] = options[:username] if options[:username]
-          connection_opts[:"sasl.password"] = options[:password] if options[:password]
-
-          connection_opts.merge!(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :username, :password))
-
           ::Rdkafka::Config.logger = logger
-          @kafka_client = ::Rdkafka::Config.new(connection_opts)
+          @kafka_client = ::Rdkafka::Config.new(rdkafka_connection_opts(options))
+        end
+
+        def rdkafka_connection_opts(options)
+          hosts = Array(options[:hosts] || options[:host])
+          hosts.collect! { |host| "#{host}:#{options[:port]}" }
+
+          result = {:"bootstrap.servers" => hosts.join(',')}
+          result[:"client.id"] = options[:client_ref] if options[:client_ref]
+          result[:"sasl.username"] = options[:username] if options[:username]
+          result[:"sasl.password"] = options[:password] if options[:password]
+
+          result.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :username, :password))
         end
       end
     end

--- a/spec/manageiq/messaging/kafka/client_spec.rb
+++ b/spec/manageiq/messaging/kafka/client_spec.rb
@@ -39,6 +39,19 @@ describe ManageIQ::Messaging::Kafka::Client do
         :"sasl.protocol" => "SASL_SSL"
       )
     end
+
+    it 'converts username/password to sasl parameters' do
+      expect(::Rdkafka::Config).to receive(:new).with(:"bootstrap.servers" => "localhost:1234", :"client.id" => "my-ref", :"sasl.username" => "user", :"sasl.password" => "password")
+
+      described_class.new(
+        :protocol        => 'Kafka',
+        :host            => 'localhost',
+        :port            => 1234,
+        :username        => "user",
+        :password        => "password",
+        :client_ref      => 'my-ref',
+      )
+    end
   end
 
   describe '#publish_topic' do


### PR DESCRIPTION
`:username` and `:password` are standard options that should be able to be passed in to the generic `ManageIQ::Messaging::Client.open()` without having to get into kafka specifics like `:"sasl.username"` or `:"sasl.password"`