### PR TITLE
Add a bulk publish option to the `#publish_topic` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ This is the one-to-many publish/subscribe pattern. Multiple subscribers can subs
 
 By default, events are delivered to live subscribers only. Some messaging systems support persistence with options.
 
+### Publish bulk messages to a topic
+
+Often it is more efficient to publish messages in bulk rather than one-at-a-time.  To do this you can use the `publish_topic_multi` API:
+
+```ruby
+  messages = [
+    {:service => 'provider_events', :event => 'powered_off', :payload => {:ems_ref => 'uid987', :timestamp => '1501091391'}},
+    {:service => 'provider_events', :event => 'powered_on', :payload => {:ems_ref => 'uid987', :timestamp => '1501091429'}},
+  ]
+
+  client.publish_topic_multi(messages)
+```
+
 ### Add your own headers to a message (Queue or Topic)
 
 If you want you can add in your own headers to the send message

--- a/README.md
+++ b/README.md
@@ -157,15 +157,15 @@ By default, events are delivered to live subscribers only. Some messaging system
 
 ### Publish bulk messages to a topic
 
-Often it is more efficient to publish messages in bulk rather than one-at-a-time.  To do this you can use the `publish_topic_multi` API:
+Often it is more efficient to publish messages in bulk rather than one-at-a-time.  To do this you can pass an array of messages to the `publish_topic` API:
 
 ```ruby
-  messages = [
-    {:service => 'provider_events', :event => 'powered_off', :payload => {:ems_ref => 'uid987', :timestamp => '1501091391'}},
-    {:service => 'provider_events', :event => 'powered_on', :payload => {:ems_ref => 'uid987', :timestamp => '1501091429'}},
-  ]
-
-  client.publish_topic_multi(messages)
+  client.publish_topic(
+    [
+      {:service => 'provider_events', :event => 'powered_off', :payload => {:ems_ref => 'uid987', :timestamp => '1501091391'}},
+      {:service => 'provider_events', :event => 'powered_on', :payload => {:ems_ref => 'uid987', :timestamp => '1501091429'}},
+    ]
+  )
 ```
 
 ### Add your own headers to a message (Queue or Topic)

--- a/lib/manageiq/messaging.rb
+++ b/lib/manageiq/messaging.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/hash'
 require 'yaml'

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -161,7 +161,8 @@ module ManageIQ
       end
 
       # Publish a message as a topic. All subscribers will receive a copy of the message.
-      # Expected keys in +options+ are:
+      # +messages+ can be either a hash or an array of hashes.
+      # Expected keys are:
       # * :service (service is used to determine the topic address)
       # * :event   (event name)
       # * :payload (message body, a string or an user object that can be serialized)
@@ -169,8 +170,8 @@ module ManageIQ
       # * :headers (optional, additional headers to add to the message)
       # Other options are underlying messaging system specific.
       #
-      def publish_topic(options)
-        messages = Array.wrap(options)
+      def publish_topic(messages)
+        messages = Array.wrap(messages)
         messages.each { |msg| assert_options(msg, [:event, :service]) }
 
         publish_topic_impl(messages)

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -170,24 +170,10 @@ module ManageIQ
       # Other options are underlying messaging system specific.
       #
       def publish_topic(options)
-        assert_options(options, [:event, :service])
+        messages = Array.wrap(options)
+        messages.each { |msg| assert_options(msg, [:event, :service]) }
 
-        publish_topic_impl(options)
-      end
-
-      # Publish multiple messages to a topic.  All subscribers will receive a copy of the message.
-      # Expected keys in +messages* (Array) are:
-      # * :service (service is used to determine the topic address)
-      # * :event   (event name)
-      # * :payload (message body, a string or an user object that can be serialized)
-      # * :sender  (optional, identify the sender)
-      # * :headers (optional, additional headers to add to the message)
-      # Other options are underlying messaging system specific.
-      #
-      def publish_topic_multi(messages)
-        raise ArgumentError, "messages must be an array" unless messages.kind_of?(Array)
-
-        publish_topic_multi_impl(messages)
+        publish_topic_impl(messages)
       end
 
       # Subscribe to receive topic type messages.

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -175,6 +175,21 @@ module ManageIQ
         publish_topic_impl(options)
       end
 
+      # Publish multiple messages to a topic.  All subscribers will receive a copy of the message.
+      # Expected keys in +messages* (Array) are:
+      # * :service (service is used to determine the topic address)
+      # * :event   (event name)
+      # * :payload (message body, a string or an user object that can be serialized)
+      # * :sender  (optional, identify the sender)
+      # * :headers (optional, additional headers to add to the message)
+      # Other options are underlying messaging system specific.
+      #
+      def publish_topic_multi(messages)
+        raise ArgumentError, "messages must be an array" unless messages.kind_of?(Array)
+
+        publish_topic_multi_impl(messages)
+      end
+
       # Subscribe to receive topic type messages.
       # Expected keys in +options+ are:
       # * :service (service is used to determine the topic address)

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -21,12 +21,9 @@ module ManageIQ
           @consumer = kafka_client.consumer
         end
 
-        def raw_publish(wait, body, options)
+        def raw_publish(body, options)
           options[:payload] = encode_body(options[:headers], body)
-          producer.produce(options).tap do |handle|
-            handle.wait if wait
-            logger.info("Published to topic(#{options[:topic]}), msg(#{payload_log(body.inspect)})")
-          end
+          producer.produce(options)
         end
 
         def queue_for_publish(options)

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -8,11 +8,11 @@ module ManageIQ
 
         def publish_message_impl(options)
           raise ArgumentError, "Kafka messaging implementation does not take a block" if block_given?
-          raw_publish(true, *queue_for_publish(options))
+          raw_publish(*queue_for_publish(options)).wait
         end
 
         def publish_messages_impl(messages)
-          handles = messages.collect { |msg_options| raw_publish(false, *queue_for_publish(msg_options)) }
+          handles = messages.collect { |msg_options| raw_publish(*queue_for_publish(msg_options)) }
           handles.each(&:wait)
         end
 

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -8,12 +8,8 @@ module ManageIQ
 
         private
 
-        def publish_topic_impl(options)
-          raw_publish(true, *topic_for_publish(options))
-        end
-
-        def publish_topic_multi_impl(messages)
-          handles = messages.map { |message| raw_publish(false, *topic_for_publish(message)) }
+        def publish_topic_impl(messages)
+          handles = messages.collect { |message| raw_publish(false, *topic_for_publish(message)) }
           handles.each(&:wait)
         end
 

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -12,6 +12,11 @@ module ManageIQ
           raw_publish(true, *topic_for_publish(options))
         end
 
+        def publish_topic_multi_impl(messages)
+          handles = messages.map { |message| raw_publish(false, *topic_for_publish(message)) }
+          handles.each(&:wait)
+        end
+
         def subscribe_topic_impl(options, &block)
           topic = address(options)
 

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -9,7 +9,7 @@ module ManageIQ
         private
 
         def publish_topic_impl(messages)
-          handles = messages.collect { |message| raw_publish(false, *topic_for_publish(message)) }
+          handles = messages.collect { |message| raw_publish(*topic_for_publish(message)) }
           handles.each(&:wait)
         end
 

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -4,7 +4,7 @@ module ManageIQ
       module Topic
         private
 
-        def publish_topic_impl(options)
+        def publish_topic_single(options)
           address, headers = topic_for_publish(options)
           headers[:sender] = options[:sender] if options[:sender]
           headers[:event_type] = options[:event] if options[:event]
@@ -12,8 +12,8 @@ module ManageIQ
           raw_publish(address, options[:payload], headers)
         end
 
-        def publish_topic_multi_impl(messages)
-          messages.each { |message| publish_topic_impl(message) }
+        def publish_topic_impl(messages)
+          messages.each { |message| publish_topic_single(message) }
         end
 
         def subscribe_topic_impl(options)

--- a/lib/manageiq/messaging/stomp/topic.rb
+++ b/lib/manageiq/messaging/stomp/topic.rb
@@ -12,6 +12,10 @@ module ManageIQ
           raw_publish(address, options[:payload], headers)
         end
 
+        def publish_topic_multi_impl(messages)
+          messages.each { |message| publish_topic_impl(message) }
+        end
+
         def subscribe_topic_impl(options)
           queue_name, headers = topic_for_subscribe(options)
 

--- a/spec/manageiq/messaging/client_spec.rb
+++ b/spec/manageiq/messaging/client_spec.rb
@@ -78,7 +78,9 @@ describe ManageIQ::Messaging::Client do
     end
 
     it 'sends an array of messages to a topic' do
-      expect(subject).to receive(:publish_topic_impl).with(kind_of(Array))
+      expect(subject)
+        .to receive(:publish_topic_impl)
+        .with(array_including(hash_including(:event => 'e'), hash_including(:event => 'b')))
       subject.publish_topic([{:service => 'a', :event => 'e'}, {:service => 'a', :event => 'b'}])
     end
   end

--- a/spec/manageiq/messaging/client_spec.rb
+++ b/spec/manageiq/messaging/client_spec.rb
@@ -78,6 +78,17 @@ describe ManageIQ::Messaging::Client do
     end
   end
 
+  describe '#publish_topic_multi' do
+    it 'requires argument to be an array' do
+      expect { subject.publish_topic_multi({}) }.to raise_error(ArgumentError)
+    end
+
+    it 'sends a message to a topic' do
+      expect(subject).to receive(:publish_topic_multi_impl)
+      subject.publish_topic_multi([:service => 'a', :event => 'e'])
+    end
+  end
+
   describe '#subscribe_topic' do
     it 'requires :service in the options' do
       expect { subject.subscribe_topic({}) {} }.to raise_error(ArgumentError)

--- a/spec/manageiq/messaging/client_spec.rb
+++ b/spec/manageiq/messaging/client_spec.rb
@@ -76,16 +76,10 @@ describe ManageIQ::Messaging::Client do
       expect(subject).to receive(:publish_topic_impl)
       subject.publish_topic(:service => 'a', :event => 'e')
     end
-  end
 
-  describe '#publish_topic_multi' do
-    it 'requires argument to be an array' do
-      expect { subject.publish_topic_multi({}) }.to raise_error(ArgumentError)
-    end
-
-    it 'sends a message to a topic' do
-      expect(subject).to receive(:publish_topic_multi_impl)
-      subject.publish_topic_multi([:service => 'a', :event => 'e'])
+    it 'sends an array of messages to a topic' do
+      expect(subject).to receive(:publish_topic_impl).with(kind_of(Array))
+      subject.publish_topic([{:service => 'a', :event => 'e'}, {:service => 'a', :event => 'b'}])
     end
   end
 


### PR DESCRIPTION
Kafka allows for far more efficient publication of multiple messages by producing many messages then waiting on them after publication.