### PR TITLE
Fix kafka publish_topic on ruby3

### DIFF
--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -23,7 +23,7 @@ module ManageIQ
 
         def raw_publish(body, options)
           options[:payload] = encode_body(options[:headers], body)
-          producer.produce(options)
+          producer.produce(**options)
         end
 
         def queue_for_publish(options)


### PR DESCRIPTION
The rdkafka producer takes kwargs (https://github.com/appsignal/rdkafka-ruby/blob/main/lib/rdkafka/producer.rb#L76) and we were passing a hash:
```
rdkafka-0.12.0/lib/rdkafka/producer.rb:74:in `produce': wrong number of arguments (given 1, expected 0; required keyword: topic) (ArgumentError)
	from /home/grare/adam/src/manageiq/manageiq-messaging/lib/manageiq/messaging/kafka/common.rb:26:in `raw_publish'
	from /home/grare/adam/src/manageiq/manageiq-messaging/lib/manageiq/messaging/kafka/topic.rb:13:in `block in publish_topic_impl'
	from /home/grare/adam/src/manageiq/manageiq-messaging/lib/manageiq/messaging/kafka/topic.rb:13:in `collect'
	from /home/grare/adam/src/manageiq/manageiq-messaging/lib/manageiq/messaging/kafka/topic.rb:13:in `publish_topic_impl'
	from /home/grare/adam/src/manageiq/manageiq-messaging/lib/manageiq/messaging/client.rb:177:in `publish_topic'
```