### PR TITLE
Add wait_for_topic option to Kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Add wait_for_topic option to Kafka (#75)
+
 ## [1.1.2] - 6-Oct-2022
 
 * Fix kafka publish_topic on ruby3 [#74](https://github.com/ManageIQ/manageiq-messaging/pull/74)

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -94,6 +94,22 @@ module ManageIQ
           end
         end
 
+        def wait_for_topic(wait = true)
+          retry_count     = 0
+          maximum_backoff = 300
+
+          begin
+            yield
+          rescue Rdkafka::RdkafkaError => err
+            raise if err.code != :unknown_topic_or_part || !wait
+
+            retry_count += 1
+            sleep([1.5 * retry_count, maximum_backoff].min)
+
+            retry
+          end
+        end
+
         def message_header_keys
           [:sender, :message_type, :class_name]
         end

--- a/lib/manageiq/messaging/kafka/queue.rb
+++ b/lib/manageiq/messaging/kafka/queue.rb
@@ -17,13 +17,18 @@ module ManageIQ
         end
 
         def subscribe_messages_impl(options, &block)
+          wait = options.delete(:wait_for_topic)
+          wait = true if wait.nil?
+
           topic = address(options)
           options[:persist_ref] = GROUP_FOR_QUEUE_MESSAGES + topic
 
-          queue_consumer = consumer(true, options)
-          queue_consumer.subscribe(topic)
-          queue_consumer.each do |message|
-            process_queue_message(queue_consumer, topic, message, &block)
+          wait_for_topic(wait) do
+            queue_consumer = consumer(true, options)
+            queue_consumer.subscribe(topic)
+            queue_consumer.each do |message|
+              process_queue_message(queue_consumer, topic, message, &block)
+            end
           end
         end
       end

--- a/lib/manageiq/messaging/kafka/topic.rb
+++ b/lib/manageiq/messaging/kafka/topic.rb
@@ -14,13 +14,19 @@ module ManageIQ
         end
 
         def subscribe_topic_impl(options, &block)
+          wait = options.delete(:wait_for_topic)
+          wait = true if wait.nil?
+
           topic = address(options)
 
           options[:persist_ref] = "#{GROUP_FOR_ADHOC_LISTENERS}_#{Time.now.to_i}" unless options[:persist_ref]
-          topic_consumer = consumer(false, options)
-          topic_consumer.subscribe(topic)
-          topic_consumer.each do |message|
-            process_topic_message(topic_consumer, topic, message, &block)
+
+          wait_for_topic(wait) do
+            topic_consumer = consumer(false, options)
+            topic_consumer.subscribe(topic)
+            topic_consumer.each do |message|
+              process_topic_message(topic_consumer, topic, message, &block)
+            end
           end
         end
       end


### PR DESCRIPTION
Add an option to Kafka subscribe_messages and subscribe_topic to wait for topic creation with increasing backoff retry.