### PR TITLE
Add ssl and ca_file options to Client.open()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-* Add wait_for_topic option to Kafka (#75)
+* Add ssl and ca_file options to `Client.open` [#76](https://github.com/ManageIQ/manageiq-messaging/pull/76)
+* Add wait_for_topic option to Kafka [#75](https://github.com/ManageIQ/manageiq-messaging/pull/75)
 
 ## [1.1.2] - 6-Oct-2022
 

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -33,6 +33,12 @@ module ManageIQ
       # Open or create a connection to the message broker.
       # Expected +options+ keys are:
       # * :protocol (Implemented: 'Stomp', 'Kafka'. Default 'Stomp')
+      # * :host (hostname or IP address of the messaging broker)
+      # * :port (host port number)
+      # * :username (optional)
+      # * :password (optional)
+      # * :ssl (true/false)
+      # * ca_file (optional. path to a certificate authority cert)
       # * :encoding ('yaml' or 'json'. Default 'yaml')
       # Other connection options are underlying messaging system specific.
       #

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -38,7 +38,7 @@ module ManageIQ
       # * :username (optional)
       # * :password (optional)
       # * :ssl (true/false)
-      # * ca_file (optional. path to a certificate authority cert)
+      # * :ca_file (optional. path to a certificate authority cert)
       # * :encoding ('yaml' or 'json'. Default 'yaml')
       # Other connection options are underlying messaging system specific.
       #

--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -8,13 +8,11 @@ module ManageIQ
       # Kafka specific connection options accepted by +open+ method:
       # * :client_ref (A reference string to identify the client)
       # * :hosts (Array of Kafka cluster hosts, or)
-      # * :host (Single host name)
-      # * :port (host port number)
       #
-      # For additional security options, please refer to 
+      # For additional security options, please refer to
       # https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka and
-      # https://github.com/edenhill/librdkafka/wiki/Using-SASL-with-librdkafka 
-      # 
+      # https://github.com/edenhill/librdkafka/wiki/Using-SASL-with-librdkafka
+      #
       #
       # Kafka specific +publish_message+ options:
       # * :group_name (Used as Kafka partition_key)
@@ -89,10 +87,14 @@ module ManageIQ
 
           result = {:"bootstrap.servers" => hosts.join(',')}
           result[:"client.id"] = options[:client_ref] if options[:client_ref]
-          result[:"sasl.username"] = options[:username] if options[:username]
-          result[:"sasl.password"] = options[:password] if options[:password]
 
-          result.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :username, :password))
+          result[:"sasl.mechanism"]    = "PLAIN"
+          result[:"sasl.username"]     = options[:username] if options[:username]
+          result[:"sasl.password"]     = options[:password] if options[:password]
+          result[:"ssl.ca.location"]   = options[:ca_file] if options[:ca_file]
+          result[:"security.protocol"] = !!options[:ssl] ? "SASL_SSL" : "PLAINTEXT"
+
+          result.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :username, :password, :ssl, :ca_file))
         end
       end
     end

--- a/lib/manageiq/messaging/stomp/client.rb
+++ b/lib/manageiq/messaging/stomp/client.rb
@@ -61,7 +61,7 @@ module ManageIQ
         attr_reader :stomp_client
 
         def initialize(options)
-          host = options.slice(:host, :port)
+          host = options.slice(:host, :port, :ssl)
           host[:passcode] = options[:password] if options[:password]
           host[:login] = options[:username] if options[:username]
 


### PR DESCRIPTION
Don't require users to pass in librdkafka specific options in order to use SSL / Certificate Authorities

Previously:
```
ManageIQ::Messaging.open(
  :protocol            => 'Kafka',
  :host                => 'localhost',
  :port                => 9092,
  :"sasl.username"     => 'user',
  :"sasl.password"     => 'password',
  :"security.protocol" => 'SASL_SSL',
  :"ssl.ca.location"   => '/path/to/cert'
)
```

Now:
```
ManageIQ::Messaging.open(
  :protocol   => 'Kafka',
  :host       => 'localhost',
  :port       => 9092,
  :username   => "user",
  :password   => 'password',
  :ssl        => true,
  :ca_file    => '/path/to/cert'
)
```