### PR TITLE
Add Kafka SSL keystore options to client

### DIFF
--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -91,10 +91,12 @@ module ManageIQ
           result[:"sasl.mechanism"]    = "PLAIN"
           result[:"sasl.username"]     = options[:username] if options[:username]
           result[:"sasl.password"]     = options[:password] if options[:password]
-          result[:"ssl.ca.location"]   = options[:ca_file] if options[:ca_file]
           result[:"security.protocol"] = !!options[:ssl] ? "SASL_SSL" : "PLAINTEXT"
+          result[:"ssl.ca.location"]   = options[:ca_file] if options[:ca_file]
+          result[:"ssl.keystore.location"] = options[:keystore_location] if options[:keystore_location]
+          result[:"ssl.keystore.password"] = options[:keystore_password] if options[:keystore_password]
 
-          result.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :username, :password, :ssl, :ca_file))
+          result.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :username, :password, :ssl, :ca_file, :keystore_location, :keystore_password))
         end
       end
     end


### PR DESCRIPTION
- keystore config options necessary for Kafka SSL on podified
- see: https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-pods/pull/951
- [ ] https://github.com/ManageIQ/manageiq/pull/22437

Ref:
- https://github.com/ManageIQ/manageiq-pods/issues/789

@miq-bot assign @agrare 
@miq-bot add_label enhancement