### PR TITLE
Kafka client options updates

### DIFF
--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -88,7 +88,7 @@ module ManageIQ
           result = {:"bootstrap.servers" => hosts.join(',')}
           result[:"client.id"] = options[:client_ref] if options[:client_ref]
 
-          result[:"sasl.mechanism"]    = "PLAIN"
+          result[:"sasl.mechanism"]    = options[:sasl_mechanism] || "PLAIN"
           result[:"sasl.username"]     = options[:username] if options[:username]
           result[:"sasl.password"]     = options[:password] if options[:password]
           result[:"security.protocol"] = !!options[:ssl] ? "SASL_SSL" : "PLAINTEXT"
@@ -96,7 +96,7 @@ module ManageIQ
           result[:"ssl.keystore.location"] = options[:keystore_location] if options[:keystore_location]
           result[:"ssl.keystore.password"] = options[:keystore_password] if options[:keystore_password]
 
-          result.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :username, :password, :ssl, :ca_file, :keystore_location, :keystore_password))
+          result.merge(options.except(:port, :host, :hosts, :encoding, :protocol, :client_ref, :sasl_mechanism, :username, :password, :ssl, :ca_file, :keystore_location, :keystore_password))
         end
       end
     end


### PR DESCRIPTION
- Added option to specify sasl mechanism allowing for another mechanism to be used in podified i.e. `SCRAM-SHA-512` and will default to PLAIN if not provided. This allows us to support other SASL mechanisms on podified without having to implement changes on the appliance side to support the same mechanism 
- Turns out keystores aren't needed because they are only used for mTLS authentication. Since we are using SASL for authentication a client side keystore isn't needed because you can only have one authentication method: SASL or mTLS. For a better explanation see https://docs.confluent.io/platform/current/kafka/configure-mds/mutual-tls-auth-rbac.html#authentication

TODO:
- [x] update specs (sasl.mechanism specs already exist)

Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/22692

@miq-bot assign @agrare 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_labels enhancement
