### PR TITLE
Handle headers with string keys

### DIFF
--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -3,6 +3,7 @@ module ManageIQ
     module Kafka
       module Common
         require 'manageiq/messaging/common'
+        require "active_support/core_ext/hash/indifferent_access"
         include ManageIQ::Messaging::Common
 
         private
@@ -116,7 +117,7 @@ module ManageIQ
 
         def parse_message_headers(headers)
           return [nil, nil, nil] unless headers.kind_of?(Hash)
-          headers.values_at(*message_header_keys)
+          headers.with_indifferent_access.values_at(*message_header_keys)
         end
 
         def event_header_keys
@@ -125,7 +126,7 @@ module ManageIQ
 
         def parse_event_headers(headers)
           return [nil, nil] unless headers.kind_of?(Hash)
-          headers.values_at(*event_header_keys)
+          headers.with_indifferent_access.values_at(*event_header_keys)
         end
       end
     end


### PR DESCRIPTION
Message hashes can also be received with string keys instead of symbols, this was causing `nil` values to be retrieved from the header hash when using the `.values_at` method, resulting in failures when using these values to invoke methods later on

For example (notice how ems/sender and event types are empty in logging):
```
Nov 28 16:00:37 agrare-im-rhv.rtp.raleigh.ibm.com evm[85076]:  INFO -- evm: MIQ(MiqQueue.process_topic_message) Event received: topic(manageiq.ems), event({"event_type"=>"USER_ADD_DISK_TO_VM", "source"=>"RHEVM", "message"=>"Add-Disk operation of Dave_Test0), sender(), type()
Nov 28 16:00:37 agrare-im-rhv.rtp.raleigh.ibm.com evm[85076]:  INFO -- evm: MIQ(MiqQueue.process_topic_message) Event processed
Nov 28 16:00:37 agrare-im-rhv.rtp.raleigh.ibm.com evm[85076]: DEBUG -- evm: MIQ(MiqQueue.process_topic_message) HEADERS: {"sender"=>"1000000000003", "event_type"=>"USER_ADD_DISK_TO_VM_FINISHED_SUCCESS", "encoding"=>"json"}
Nov 28 16:00:37 agrare-im-rhv.rtp.raleigh.ibm.com evm[85076]:  INFO -- evm: MIQ(MiqQueue.process_topic_message) Event received: topic(manageiq.ems), event({"event_type"=>"USER_ADD_DISK_TO_VM_FINISHED_SUCCESS", "source"=>"RHEVM", "message"=>"The disk Dave_T), sender(), type()
Nov 28 16:00:37 agrare-im-rhv.rtp.raleigh.ibm.com evm[85076]:  INFO -- evm: MIQ(MiqQueue.process_topic_message) Event processed
Nov 28 16:00:40 agrare-im-rhv.rtp.raleigh.ibm.com evm[85076]:  INFO -- evm: MIQ(EmsEventHelper#before_handle) Processing EMS event [USER_ADD_DISK_TO_VM] chain_id [] on EMS []...
Nov 28 16:00:40 agrare-im-rhv.rtp.raleigh.ibm.com evm[85076]: ERROR -- evm: [NoMethodError]: undefined method `tenant_identity' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
Nov 28 16:00:40 agrare-im-rhv.rtp.raleigh.ibm.com evm[85076]: ERROR -- evm: /var/www/miq/vmdb/app/models/ems_event.rb:268:in `tenant_identity'
                                                              /opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-automation_engine-04fdd2d78066/lib/miq_automation_engine/engine/miq_ae_event.rb:136:in `call_automate'
                                                              /opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-automation_engine-04fdd2d78066/lib/miq_automation_engine/engine/miq_ae_event.rb:33:in `raise_ems_event'
```

@miq-bot assign @agrare 
@miq-bot add_labels bug, kafka