### PR TITLE
Allow rails 7 gems in gemspec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.6'
         - '2.7'
         - '3.0'
         rails-version:
         - '6.0'
         - '6.1'
+        - '7.0'
     env:
       TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,14 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in manageiq-messaging.gemspec
 gemspec
 
-case ENV['TEST_RAILS_VERSION']
-when "6.0"
-  gem "activesupport", "~>6.0.4"
-when "6.1"
-  gem "activesupport", "~>6.1.4"
-end
+minimum_version =
+  case ENV['TEST_RAILS_VERSION']
+  when "6.0"
+    "~>6.0.4"
+  when "7.0"
+    "~>7.0.8"
+  else
+    "~>6.1.4"
+  end
+
+gem "activesupport", minimum_version

--- a/manageiq-messaging.gemspec
+++ b/manageiq-messaging.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activesupport', '>= 5.2.4.3', "< 7.0"
+  spec.add_dependency 'activesupport', '>= 5.2.4.3', "<7.1"
   spec.add_dependency 'rdkafka', '~> 0.8'
   spec.add_dependency 'stomp', '~> 1.4.4'
 


### PR DESCRIPTION
Allow rails 7 gems in gemspec

Note, this PR drops ruby 2.6 from tests.

Ruby 2.6 is EOL and not supported by rails 7.  If we really need it, can
test ruby 2.6 against rails < 7.