### PR TITLE
Fix Kafka Client List Topics Method

### DIFF
--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -65,8 +65,7 @@ module ManageIQ
 
         # list all topics
         def topics
-          native_kafka = producer.instance_variable_get(:@native_kafka)
-          Rdkafka::Metadata.new(native_kafka).topics.collect { |topic| topic[:topic_name] }
+          kafka_client.admin.metadata.topics.map { |topic| topic[:topic_name] }
         end
 
         private


### PR DESCRIPTION
This method uses the rdkafka admin API to retrieve metadata from the kafka server. This is a good way to perform health checks since if the kafka server is down, this will return an error instead. 

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_label enhancement
