### PR TITLE
Close Kafka admin client connection

### DIFF
--- a/lib/manageiq/messaging/kafka/client.rb
+++ b/lib/manageiq/messaging/kafka/client.rb
@@ -56,6 +56,9 @@ module ManageIQ
         end
 
         def close
+          @admin&.close
+          @admin = nil
+
           @producer&.close
           @producer = nil
 
@@ -65,7 +68,7 @@ module ManageIQ
 
         # list all topics
         def topics
-          kafka_client.admin.metadata.topics.map { |topic| topic[:topic_name] }
+          admin.metadata.topics.map { |topic| topic[:topic_name] }
         end
 
         private

--- a/lib/manageiq/messaging/kafka/common.rb
+++ b/lib/manageiq/messaging/kafka/common.rb
@@ -8,6 +8,10 @@ module ManageIQ
 
         private
 
+        def admin
+          @admin ||= kafka_client.admin
+        end
+
         def producer
           @producer ||= kafka_client.producer
         end


### PR DESCRIPTION
The rdkafka admin client connection should be closed similar to how its done for producers/consumers to avoid unwanted behaviour

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_label bug