### PR TITLE
Update ruby rails dependencies (breaking change)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,13 +12,17 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
         - '3.0'
         - '3.1'
+        - '3.2'
+        - '3.3'
         rails-version:
-        - '6.0'
-        - '6.1'
         - '7.0'
+        - '7.1'
+        - '7.2'
+        exclude:
+        - ruby-version: '3.0'
+          rails-version: '7.2'
     env:
       TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,12 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
-  when "6.0"
-    "~>6.0.4"
-  when "7.0"
-    "~>7.0.8"
+  when "7.2"
+    "~>7.2.1"
+  when "7.1"
+    "~>7.1.4"
   else
-    "~>6.1.4"
+    "~>7.0.8"
   end
 
 gem "activesupport", minimum_version

--- a/manageiq-messaging.gemspec
+++ b/manageiq-messaging.gemspec
@@ -6,7 +6,7 @@ require 'manageiq/messaging/version'
 Gem::Specification.new do |spec|
   spec.name                  = "manageiq-messaging"
   spec.version               = ManageIQ::Messaging::VERSION
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.0'
   spec.authors               = ["ManageIQ Authors"]
 
   spec.summary       = 'Client library for ManageIQ components to exchange messages through its internal message bus.'

--- a/manageiq-messaging.gemspec
+++ b/manageiq-messaging.gemspec
@@ -6,7 +6,7 @@ require 'manageiq/messaging/version'
 Gem::Specification.new do |spec|
   spec.name                  = "manageiq-messaging"
   spec.version               = ManageIQ::Messaging::VERSION
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 3.1'
   spec.authors               = ["ManageIQ Authors"]
 
   spec.summary       = 'Client library for ManageIQ components to exchange messages through its internal message bus.'
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activesupport', '>= 5.2.4.3', "<7.1"
+  spec.add_dependency 'activesupport', '>= 7.0.8', "<8.0"
   spec.add_dependency 'rdkafka', '~> 0.8'
   spec.add_dependency 'stomp', '~> 1.4.4'
 


### PR DESCRIPTION
### Use core minimum but allow 7.0/7.1/7.2 since core sets upper limit
### Drop end of life rubies and rails and add new versions

Ensure we're testing and supporting community supported
versions.

Drop:
* ruby 2.7
* rails 6.0
* rails 6.1

Add:
* ruby 3.2
* ruby 3.3
* rails 7.1
* rails 7.2

Note: ruby 3.0 is not difficult to keep maintaining for now but it's on the chopping block.