### PR TITLE
Don't default to protocol=Stomp

### DIFF
--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -32,7 +32,7 @@ module ManageIQ
     class Client
       # Open or create a connection to the message broker.
       # Expected +options+ keys are:
-      # * :protocol (Implemented: 'Stomp', 'Kafka'. Default 'Stomp')
+      # * :protocol (Implemented: 'Stomp', 'Kafka')
       # * :host (hostname or IP address of the messaging broker)
       # * :port (host port number)
       # * :username (optional)
@@ -44,8 +44,14 @@ module ManageIQ
       #
       # Returns a +Client+ instance if no block is given.
       def self.open(options)
-        protocol = options[:protocol] || :Stomp
-        client = Object.const_get("ManageIQ::Messaging::#{protocol}::Client").new(options)
+        protocol = options[:protocol]
+        raise ArgumentError, "Missing protocol" if protocol.nil?
+
+        client = begin
+                   Object.const_get("ManageIQ::Messaging::#{protocol}::Client").new(options)
+                 rescue NameError
+                   raise ArgumentError, "Invalid protocol: #{protocol}"
+                 end
 
         return client unless block_given?
 

--- a/spec/manageiq/messaging/client_spec.rb
+++ b/spec/manageiq/messaging/client_spec.rb
@@ -4,8 +4,16 @@ describe ManageIQ::Messaging::Client do
   subject { described_class.open({:protocol => 'Test'}) }
 
   describe '.open' do
+    it 'without a protocol raises an exception' do
+      expect { described_class.open({}) }.to raise_error(ArgumentError, /Missing protocol/)
+    end
+
     it 'creates an instance of a type specific client' do
       expect(subject).to be_kind_of(ManageIQ::Messaging::Test::Client)
+    end
+
+    it 'with an invalid protocol' do
+      expect { described_class.open(:protocol => 'Invalid') }.to raise_error(ArgumentError, /Invalid protocol/)
     end
 
     it 'closes the client before exit if it opens with a block' do


### PR DESCRIPTION
If a protocol option isn't passed we shouldn't just default to Stomp as that can cause unexpected issues if protocol is missing but the user is expecting to use kafka.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
